### PR TITLE
Fix location update bug

### DIFF
--- a/GoInfoGame/GoInfoGame/LocationManagerDelegate.swift
+++ b/GoInfoGame/GoInfoGame/LocationManagerDelegate.swift
@@ -14,6 +14,8 @@ class LocationManagerDelegate: NSObject, ObservableObject, CLLocationManagerDele
     @Published var location: CLLocation?
     var locationUpdateHandler: ((CLLocation) -> Void)?
     
+    var hasUpdatedLocation = false
+    
     override init() {
         super.init()
     }
@@ -56,8 +58,10 @@ class LocationManagerDelegate: NSObject, ObservableObject, CLLocationManagerDele
     
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         guard let mostRecentLocation = locations.last else { return }
+        guard !hasUpdatedLocation else { return }
         location = mostRecentLocation
         locationUpdateHandler?(mostRecentLocation)
+        hasUpdatedLocation = true
         stopUpdatingLocation()
     }
 }


### PR DESCRIPTION
Fixes the bug by adding a flag to prevent didUpdateLocations getting called unnecessarily. Thereby fetch API will be called only once.