### PR TITLE
refresh token error handling 

### DIFF
--- a/GoInfoGame/GoInfoGame/AppDelegate.swift
+++ b/GoInfoGame/GoInfoGame/AppDelegate.swift
@@ -5,7 +5,7 @@
 //  Created by Achyut Kumar M on 09/11/23.
 //
 
-import UIKit
+import SwiftUI
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -54,7 +54,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if timeIntervalFromSessionCreation >= sessionFireTime {
             refreshToken()
         } else {
-            refreshTokenTime = Timer(timeInterval: sessionFireTime - timeIntervalFromSessionCreation, repeats: false, block: { [weak self] _ in
+            refreshTokenTime = Timer.scheduledTimer(withTimeInterval: sessionFireTime - timeIntervalFromSessionCreation, repeats: false, block: { [weak self] _ in
                 self?.refreshToken()
             })
         }
@@ -63,6 +63,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private func refreshToken() {
         TokenRefresher.shared.refreshToken { status in
             print("Refresh status \(status)")
+            if status == false {
+                DispatchQueue.main.async {
+                    Utilities.clearAllData()
+                    if let window = UIApplication.window() {
+                        window.rootViewController = UIHostingController(rootView: PosmLoginView())
+                    }
+                }
+            }
         }
     }
 

--- a/GoInfoGame/GoInfoGame/Helpers/Extensions.swift
+++ b/GoInfoGame/GoInfoGame/Helpers/Extensions.swift
@@ -116,3 +116,9 @@ extension SCNGeometry {
         return SCNGeometry(sources: [sources], elements: [element])
     }
 }
+
+extension UIApplication {
+    static func window() -> UIWindow? {
+        return UIApplication.shared.connectedScenes.flatMap { ($0 as? UIWindowScene)?.windows ?? [] }.first { $0.isKeyWindow }
+    }
+}

--- a/GoInfoGame/GoInfoGame/Helpers/Utils.swift
+++ b/GoInfoGame/GoInfoGame/Helpers/Utils.swift
@@ -43,5 +43,7 @@ struct Utilities {
         _ = KeychainManager.delete(key: "username")
         loggedIn = false
         UserProfileCache.shared.clearUserProfile()
+        UserDefaults.standard.removeObject(forKey: "accessToken_Generate")
+        UserDefaults.standard.removeObject(forKey: "accessToken_expire_in")
     }
 }

--- a/GoInfoGame/GoInfoGame/Helpers/Utils.swift
+++ b/GoInfoGame/GoInfoGame/Helpers/Utils.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import UIKit
+import SwiftUI
 
 /// for navigationController pop view controllers
 struct NavigationUtil {
@@ -32,5 +32,16 @@ struct NavigationUtil {
         }
         
         return nil
+    }
+}
+
+struct Utilities {
+    static func clearAllData() {
+        @AppStorage("loggedIn") var loggedIn: Bool = false
+        _ = KeychainManager.delete(key: "accessToken")
+        _ = KeychainManager.delete(key: "refreshToken")
+        _ = KeychainManager.delete(key: "username")
+        loggedIn = false
+        UserProfileCache.shared.clearUserProfile()
     }
 }

--- a/GoInfoGame/GoInfoGame/Login/View/PosmLogin.swift
+++ b/GoInfoGame/GoInfoGame/Login/View/PosmLogin.swift
@@ -17,7 +17,7 @@ struct PosmLoginView: View {
     @State private var shouldShowAlert = false
     
     @State private var selectedEnvironment: APIEnvironment = .staging
-    
+    @State private var showAlert = false
     var body: some View {
         NavigationStack {
             ZStack {
@@ -98,6 +98,14 @@ struct PosmLoginView: View {
         .onAppear {
             selectedEnvironment = APIConfiguration.shared.environment
         }
+        .onReceive(NotificationCenter.default.publisher(for: Notification.Name("SessionExpired"))) { notification in
+                    showAlert = true
+                }
+                .alert("Logout", isPresented: $showAlert) {
+                    Button("OK", role: .cancel) {}
+                } message: {
+                    Text("Your session has expired. Please login again")
+                }
     }
 }
 

--- a/GoInfoGame/GoInfoGame/Login/ViewModel/PosmLoginViewModel.swift
+++ b/GoInfoGame/GoInfoGame/Login/ViewModel/PosmLoginViewModel.swift
@@ -66,6 +66,9 @@ class PosmLoginViewModel: ObservableObject {
                         _ = KeychainManager.save(key: "refreshToken", data: refreshToken)
                         UserDefaults.standard.setValue(posmLoginSuccessResponse.expiresIn, forKey: "accessToken_expire_in")
                         UserDefaults.standard.setValue(Date().timeIntervalSince1970, forKey: "accessToken_Generate")
+                        if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
+                            appDelegate.validateAccessToken()
+                        }
                         self.hasLoginFailed = false
                         self.loggedIn = true
                         self.isLoading = false

--- a/GoInfoGame/GoInfoGame/Network/ApiManager.swift
+++ b/GoInfoGame/GoInfoGame/Network/ApiManager.swift
@@ -243,6 +243,9 @@ class ApiManager {
                             if let window = UIApplication.window() {
                                 Utilities.clearAllData()
                                 window.rootViewController = UIHostingController(rootView: PosmLoginView())
+                                DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                                    NotificationCenter.default.post(name: Notification.Name("SessionExpired"), object: nil)
+                                }
                             }
                         }
                     }

--- a/GoInfoGame/GoInfoGame/Network/ApiManager.swift
+++ b/GoInfoGame/GoInfoGame/Network/ApiManager.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import osmapi
+import SwiftUI
 
 enum SetupType {
     case workspace
@@ -227,12 +228,23 @@ class ApiManager {
             if let httpResponse = response as? HTTPURLResponse,
                 httpResponse.statusCode == 401,
                 request.url!.lastPathComponent.contains("refresh-token") == false {
+                print("Failed requests: \(String(describing: request.url))")
                 TokenRefresher.shared.refreshToken { [weak self] status in
                     if status {
-                        self?.performRequest(to: endpoint, setupType: setupType, modelType: modelType, completion: completion)
+                        let accessToken = KeychainManager.load(key: "accessToken") ?? ""
+                        var headers = endpoint.headers
+                        headers?["Authorization"] = "Bearer \(accessToken)"
+                        let urlEndPont = APIEndpoint(path: endpoint.path, method: endpoint.method, body: endpoint.body, headers: headers, formData: endpoint.formData)
+                        self?.performRequest(to: urlEndPont, setupType: setupType, modelType: modelType, completion: completion)
                     }
                     else {
                         completion(.failure(NSError(domain: "", code: -3, userInfo: [NSLocalizedDescriptionKey: "Token refresh error"])))
+                        DispatchQueue.main.async {
+                            if let window = UIApplication.window() {
+                                Utilities.clearAllData()
+                                window.rootViewController = UIHostingController(rootView: PosmLoginView())
+                            }
+                        }
                     }
                 }
                 return

--- a/GoInfoGame/GoInfoGame/Network/TokenRefresher.swift
+++ b/GoInfoGame/GoInfoGame/Network/TokenRefresher.swift
@@ -32,7 +32,7 @@ class TokenRefresher {
                 appDelegate.invalidateRefreshTokenTimer()
             }
         }
-        print("refreshToken \(String(describing: refreshToken))")
+
         ApiManager.shared.performRequest(to: .refreshToken(refreshToken ?? ""), setupType: .login, modelType: PosmLoginSuccessResponse.self) { [weak self] result in
             
             guard let self = self else { return }

--- a/GoInfoGame/GoInfoGame/Network/TokenRefresher.swift
+++ b/GoInfoGame/GoInfoGame/Network/TokenRefresher.swift
@@ -27,10 +27,12 @@ class TokenRefresher {
             self.isRefreshing = true
         }
         let refreshToken = KeychainManager.load(key: "refreshToken")
-        if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
-            appDelegate.invalidateRefreshTokenTimer()
+        DispatchQueue.main.async {
+            if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
+                appDelegate.invalidateRefreshTokenTimer()
+            }
         }
-        
+        print("refreshToken \(String(describing: refreshToken))")
         ApiManager.shared.performRequest(to: .refreshToken(refreshToken ?? ""), setupType: .login, modelType: PosmLoginSuccessResponse.self) { [weak self] result in
             
             guard let self = self else { return }
@@ -46,8 +48,10 @@ class TokenRefresher {
                 _ = KeychainManager.save(key: "accessToken", data: resp.accessToken)
                 UserDefaults.standard.setValue(resp.expiresIn, forKey: "accessToken_expire_in")
                 UserDefaults.standard.setValue(Date().timeIntervalSince1970, forKey: "accessToken_Generate")
-                if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
-                    appDelegate.validateAccessToken()
+                DispatchQueue.main.async {
+                    if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
+                        appDelegate.validateAccessToken()
+                    }
                 }
                 success = true
                 break

--- a/GoInfoGame/GoInfoGame/UserProfile/View/UserProfileView.swift
+++ b/GoInfoGame/GoInfoGame/UserProfile/View/UserProfileView.swift
@@ -64,13 +64,9 @@ struct UserProfileView: View {
         
     private var logOutButton: some View {
         Button {
-            _ = KeychainManager.delete(key: "accessToken")
-            _ = KeychainManager.delete(key: "refreshToken")
-            _ = KeychainManager.delete(key: "username")
-        loggedIn = false
-            UserProfileCache.shared.clearUserProfile()
+            Utilities.clearAllData()
             
-            if let window = UIApplication.shared.windows.first {
+            if let window = UIApplication.window() {
                    window.rootViewController = UIHostingController(rootView: PosmLoginView())
                }
           //  accessToken = nil


### PR DESCRIPTION
Implemented redirecting the user to the login screen when the refresh token returns an error or expired. Also fixed a couple of issues related to adding new access tokens to the queued requests, time issues etc.
![Simulator Screenshot - iPhone 15 Pro - 2025-03-12 at 00 49 20](https://github.com/user-attachments/assets/5ebfa9f8-5c38-477f-8010-30b0dcdbba2b)
