### PR TITLE
Undo feature implememtation

### DIFF
--- a/GoInfoGame/GoInfoGame/AppQuestManager.swift
+++ b/GoInfoGame/GoInfoGame/AppQuestManager.swift
@@ -10,6 +10,7 @@ import Foundation
 import osmparser
 import MapKit
 import osmapi
+import RealmSwift
 
 
 // Class that handles data handling and display of annotations
@@ -134,6 +135,56 @@ class AppQuestManager {
         let hiddenIds = HiddenQuestManager.shared.hiddenQuests.map { $0.id }
         let unitsToBeDisplayed = displayUnits.filter { !hiddenIds.contains($0.id) }
         return unitsToBeDisplayed
+    }
+    
+    // FIXME: Make this function better
+    // Fetches the quest for a specific changeset based on the element
+    // If there is no need to show the element after undo, it will return nil
+    func fetchQuestForChangeset(storedChangesetId: String) -> DisplayUnitWithCoordinate? {
+        if let changeset = dbInstance.getChangeset(for: storedChangesetId) {
+            // Get the element based on the changeset
+            let storedElementId = changeset.elementId
+            let storedElementType = changeset.elementType
+            var parserElement: osmparser.Element? = nil
+            if (storedElementType == .node) {
+               let storedElement = dbInstance.getNode(id: storedElementId, version: .original)
+                parserElement = storedElement?.asNode()
+            }
+            else if (storedElementType == .way){
+               let storedElement = dbInstance.getWay(id: storedElementId, version: .original)
+                parserElement = storedElement?.asWay()
+            }
+            if let parserElement = parserElement {
+                let allQuests = QuestsRepository.shared.applicableQuests
+                for quest in allQuests {
+                    if quest.quest.filter.isEmpty {
+                        continue
+                    }
+                    if quest.quest.isApplicable(element: parserElement){
+                        let duplicateQuest = quest.quest.copyWithElement(element: parserElement)
+                        // Assign stuff based on the type of element
+                        if parserElement.type == .node {
+                            if let nodObj = parserElement as? osmparser.Node {
+                                let unit = DisplayUnitWithCoordinate(displayUnit: duplicateQuest.displayUnit, coordinateInfo:  CLLocationCoordinate2D(latitude: nodObj.position.latitude, longitude: nodObj.position.longitude), id: nodObj.id, isHidden: false)
+                                return unit
+                            }
+                          
+                        }
+                        else if parserElement.type == .way {
+                            let position  = dbInstance.getCenterForWay(id: String(parserElement.id)) ?? CLLocationCoordinate2D()
+                            let unit = DisplayUnitWithCoordinate(displayUnit: duplicateQuest.displayUnit, coordinateInfo: position, id: parserElement.id, isHidden: false)
+                            return unit
+                        }
+                        
+                    }
+                }
+                
+            }
+            
+           
+            
+        }
+        return nil
     }
 }
 

--- a/GoInfoGame/GoInfoGame/DataBase/DBModels/StoredChangeset.swift
+++ b/GoInfoGame/GoInfoGame/DataBase/DBModels/StoredChangeset.swift
@@ -43,6 +43,8 @@ class StoredChangeset: Object {
     @Persisted var point: CLLocationCoordinate2D = CLLocationCoordinate2D(latitude: 0.0, longitude: 0.0)
     @Persisted var nodes: List<Int64> = List<Int64>()
     @Persisted var updatedVersion: Int = -1
+    @Persisted var isUndoCompleted: Bool = false
+    @Persisted var undoOn: Date? = nil
     
     public func asOSMWay(isUndo: Bool = false) -> OSMWay {
         var storage = originalTags.toDictionary()

--- a/GoInfoGame/GoInfoGame/DataBase/DBModels/StoredChangeset.swift
+++ b/GoInfoGame/GoInfoGame/DataBase/DBModels/StoredChangeset.swift
@@ -16,6 +16,17 @@ enum StoredElementEnum: String, PersistableEnum {
     case node
     case way
     case unknown
+    
+    func elementType() -> ElementType {
+        switch self {
+        case .node:
+            return .node
+        case .way:
+            return .way
+        default:
+            return .node
+        }
+    }
 }
 
 // Represents one stored way

--- a/GoInfoGame/GoInfoGame/DataBase/DBModels/StoredChangeset.swift
+++ b/GoInfoGame/GoInfoGame/DataBase/DBModels/StoredChangeset.swift
@@ -9,6 +9,8 @@ import Foundation
 
 import RealmSwift
 import osmparser
+import CoreLocation
+import osmapi
 
 enum StoredElementEnum: String, PersistableEnum {
     case node
@@ -21,8 +23,29 @@ class StoredChangeset: Object {
     @Persisted(primaryKey: true) var id: String = UUID().uuidString // Internal ID
     // Type of change -> can be node or way
     @Persisted var elementType : StoredElementEnum = .unknown
-    @Persisted var elementId: String = "" // The ID of the element
+    @Persisted var elementId: Int // The ID of the element
     @Persisted var tags = Map<String,String>()
+    @Persisted var originalTags = Map<String,String>()
     @Persisted var changesetId: Int = -1 // Initial value of changeset // To be figured out later as index
     @Persisted var timestamp : String = "" // User time stamp
+    @Persisted var version: Int = 0
+    @Persisted var point: CLLocationCoordinate2D = CLLocationCoordinate2D(latitude: 0.0, longitude: 0.0)
+    @Persisted var nodes: List<Int64> = List<Int64>()
+    
+    public func asOSMWay() -> OSMWay {
+        var storage = originalTags.toDictionary()
+        for tag in tags {
+            storage[tag.key] = tag.value
+        }
+        let nodes = Array(nodes.map { Int($0) })
+        return OSMWay(type: "way", id: elementId, timestamp: Date(), version: version, changeset: -1, user: "", uid: -1, nodes: nodes, tags: storage)
+    }
+    
+    public func asOSMNode() -> OSMNode {
+        var storage = originalTags.toDictionary()
+        for tag in tags {
+            storage[tag.key] = tag.value
+        }
+        return OSMNode(type: "node", id: elementId, lat: point.latitude, lon: point.longitude, timestamp: Date(), version: version, changeset: -1, user: "", uid: -1, tags: storage)
+    }
 }

--- a/GoInfoGame/GoInfoGame/DataBase/DBModels/StoredChangeset.swift
+++ b/GoInfoGame/GoInfoGame/DataBase/DBModels/StoredChangeset.swift
@@ -42,21 +42,43 @@ class StoredChangeset: Object {
     @Persisted var version: Int = 0
     @Persisted var point: CLLocationCoordinate2D = CLLocationCoordinate2D(latitude: 0.0, longitude: 0.0)
     @Persisted var nodes: List<Int64> = List<Int64>()
+    @Persisted var updatedVersion: Int = -1
     
-    public func asOSMWay() -> OSMWay {
+    public func asOSMWay(isUndo: Bool = false) -> OSMWay {
         var storage = originalTags.toDictionary()
-        for tag in tags {
-            storage[tag.key] = tag.value
+        if !isUndo {
+            for tag in tags {
+                storage[tag.key] = tag.value
+            }
         }
         let nodes = Array(nodes.map { Int($0) })
-        return OSMWay(type: "way", id: elementId, timestamp: Date(), version: version, changeset: -1, user: "", uid: -1, nodes: nodes, tags: storage)
+        return OSMWay(type: "way",
+                      id: elementId,
+                      timestamp: Date(),
+                      version: isUndo ? updatedVersion : version,
+                      changeset: -1,
+                      user: "",
+                      uid: -1,
+                      nodes: nodes,
+                      tags: storage)
     }
     
-    public func asOSMNode() -> OSMNode {
+    public func asOSMNode(isUndo: Bool = false) -> OSMNode {
         var storage = originalTags.toDictionary()
-        for tag in tags {
-            storage[tag.key] = tag.value
+        if !isUndo {
+            for tag in tags {
+                storage[tag.key] = tag.value
+            }
         }
-        return OSMNode(type: "node", id: elementId, lat: point.latitude, lon: point.longitude, timestamp: Date(), version: version, changeset: -1, user: "", uid: -1, tags: storage)
+        return OSMNode(type: "node",
+                       id: elementId,
+                       lat: point.latitude,
+                       lon: point.longitude,
+                       timestamp: Date(),
+                       version: isUndo ? updatedVersion : version,
+                       changeset: -1,
+                       user: "",
+                       uid: -1,
+                       tags: storage)
     }
 }

--- a/GoInfoGame/GoInfoGame/DataBase/DBModels/StoredElement.swift
+++ b/GoInfoGame/GoInfoGame/DataBase/DBModels/StoredElement.swift
@@ -18,7 +18,7 @@ class StoredElement : Object {
     public func asNode() -> Node {
         let position = LatLon(latitude: 0.0, longitude: 0.0)
         var theTags: [String:String] = [:]
-        for (key,value) in tags.asKeyValueSequence(){
+        for (key,value) in tags{
             theTags[key] = value
         }
         let n = Node(id: Int64(id), version: version, tags: theTags, timestampEdited: 0, position: position)

--- a/GoInfoGame/GoInfoGame/DataBase/DBModels/StoredNode.swift
+++ b/GoInfoGame/GoInfoGame/DataBase/DBModels/StoredNode.swift
@@ -31,7 +31,7 @@ class StoredNode : Object {
     public func asNode() -> Node {
         let position = LatLon(latitude: point.latitude , longitude: point.longitude)
         var theTags: [String:String] = [:]
-        for (key,value) in tags.asKeyValueSequence(){
+        for (key,value) in tags{
             theTags[key] = value
         }
         let n = Node(id: Int64(id), version: version, tags: theTags, timestampEdited: 0, position: position)

--- a/GoInfoGame/GoInfoGame/DataBase/DBModels/StoredNode.swift
+++ b/GoInfoGame/GoInfoGame/DataBase/DBModels/StoredNode.swift
@@ -37,12 +37,4 @@ class StoredNode : Object {
         let n = Node(id: Int64(id), version: version, tags: theTags, timestampEdited: 0, position: position)
         return n
     }
-    
-    public func asOSMNode() -> OSMNode {
-        var storage = [String: String]()
-        for tag in tags {
-            storage[tag.key] = tag.value
-        }
-        return OSMNode(type: "node", id: id, lat: point.latitude, lon: point.longitude, timestamp: Date(), version: version, changeset: -1, user: "", uid: -1, tags: storage)
-    }
 }

--- a/GoInfoGame/GoInfoGame/DataBase/DBModels/StoredWay.swift
+++ b/GoInfoGame/GoInfoGame/DataBase/DBModels/StoredWay.swift
@@ -59,13 +59,4 @@ class StoredWay: Object {
         way.polyline = latLong
         return way
     }
-    
-    public func asOSMWay() -> OSMWay {
-        var storage = [String: String]()
-        for tag in tags {
-            storage[tag.key] = tag.value
-        }
-        let nodes = Array(nodes.map { Int($0) })
-        return OSMWay(type: "way", id: id, timestamp: Date(), version: version, changeset: -1, user: "", uid: -1, nodes: nodes, tags: storage)
-    }
 }

--- a/GoInfoGame/GoInfoGame/DataBase/DBModels/StoredWay.swift
+++ b/GoInfoGame/GoInfoGame/DataBase/DBModels/StoredWay.swift
@@ -44,7 +44,7 @@ class StoredWay: Object {
     
     public func asWay() -> Way {
         var theTags: [String:String] = [:]
-        for (key,value) in tags.asKeyValueSequence(){
+        for (key,value) in tags{
             theTags[key] = value
         }
         let nodeList:[Int64] = nodes.map({$0})

--- a/GoInfoGame/GoInfoGame/DataBase/DatabaseConnector.swift
+++ b/GoInfoGame/GoInfoGame/DataBase/DatabaseConnector.swift
@@ -440,6 +440,21 @@ class DatabaseConnector {
         }
     }
     
+    func updateChangesetWithUndoResultSuccess(obj:String) -> StoredChangeset? {
+        guard let changeset = realm.object(ofType: StoredChangeset.self, forPrimaryKey: obj) else {
+            return nil
+        }
+        do {
+            try realm.write {
+                changeset.undoOn = Date()
+                changeset.isUndoCompleted = true
+            }
+            return changeset
+        } catch (let error){
+            return nil
+        }
+    }
+    
     func updateNodeVersion(nodeId: String, version:Int) -> StoredNode?{
         let intId = Int(nodeId) ?? -1
         guard let theNode = getNode(id: intId, version: .original) else { return nil }

--- a/GoInfoGame/GoInfoGame/DataBase/DatabaseConnector.swift
+++ b/GoInfoGame/GoInfoGame/DataBase/DatabaseConnector.swift
@@ -130,6 +130,8 @@ class DatabaseConnector {
             print("Error clearing DB")
         }
     }
+    
+   
 
     func saveElements(_ elements: [OSMWay]) {
         do {

--- a/GoInfoGame/GoInfoGame/DataBase/DatabaseConnector.swift
+++ b/GoInfoGame/GoInfoGame/DataBase/DatabaseConnector.swift
@@ -416,9 +416,8 @@ class DatabaseConnector {
     
     func getChangeset(for id: Int64, type: ElementType) -> StoredChangeset? {
         let storedType: StoredElementEnum = (type == .way) ? .way : .node
-        let stringId = String(id)
         return realm.objects(StoredChangeset.self)
-            .filter("elementId == %@ AND elementType == %@", stringId, storedType.rawValue)
+            .filter("elementId == %@ AND elementType == %@", id, storedType.rawValue)
             .first
     }
 
@@ -426,13 +425,14 @@ class DatabaseConnector {
     /// - parameter obj: Internal id for the changeset in the database (unique ID)
     /// - parameter changesetId: Assigned changeset ID from the server
     /// - Returns updated `StoredChangeset`
-    func assignChangesetId(obj:String, changesetId: Int) -> StoredChangeset? {
+    func assignChangesetId(obj:String, changesetId: Int, updatedVersion: Int) -> StoredChangeset? {
         guard let changeset = realm.object(ofType: StoredChangeset.self, forPrimaryKey: obj) else {
             return nil
         }
         do {
             try realm.write {
                 changeset.changesetId = changesetId // Not sure if this changes the value
+                changeset.updatedVersion = updatedVersion
             }
             return changeset
         } catch (let error){
@@ -442,7 +442,7 @@ class DatabaseConnector {
     
     func updateNodeVersion(nodeId: String, version:Int) -> StoredNode?{
         let intId = Int(nodeId) ?? -1
-        guard let theNode = getNode(id: intId, version: .edited) else { return nil }
+        guard let theNode = getNode(id: intId, version: .original) else { return nil }
         do {
             try realm.write {
                 theNode.version = version
@@ -457,7 +457,7 @@ class DatabaseConnector {
     
     func updateWayVersion(wayId: String, version: Int) -> StoredWay? {
         let intId = Int(wayId) ?? -1
-        guard let theWay = getWay(id: intId, version: .edited) else { return nil }
+        guard let theWay = getWay(id: intId, version: .original) else { return nil }
         
         do {
             try realm.write {

--- a/GoInfoGame/GoInfoGame/DataBase/DatabaseConnector.swift
+++ b/GoInfoGame/GoInfoGame/DataBase/DatabaseConnector.swift
@@ -414,11 +414,8 @@ class DatabaseConnector {
         return results
     }
     
-    func getChangeset(for id: Int64, type: ElementType) -> StoredChangeset? {
-        let storedType: StoredElementEnum = (type == .way) ? .way : .node
-        return realm.objects(StoredChangeset.self)
-            .filter("elementId == %@ AND elementType == %@", id, storedType.rawValue)
-            .first
+    func getChangeset(for id: String) -> StoredChangeset? {
+        return realm.object(ofType: StoredChangeset.self, forPrimaryKey: id)
     }
 
     /// Assigns changesetId for a stored changeset

--- a/GoInfoGame/GoInfoGame/DataBase/DatabaseConnector.swift
+++ b/GoInfoGame/GoInfoGame/DataBase/DatabaseConnector.swift
@@ -248,54 +248,23 @@ class DatabaseConnector {
      @param tags `[String:String]` map of the added tags
      @return `StoredWay`
      */    
-    func addWayTags(id: String, tags: [String: String]) -> StoredWay? {
-        let intId = Int(id) ?? -1
+    func addWayTags(id: Int, tags: [String: String], version: Int) -> StoredWay? {
 
         // Step 1: Try to get the editable copy first
-        if let editable = getWay(id: intId, version: .edited) {
+        if let editable = getWay(id: id, version: .original) {
             // Step 2: Update the existing editable copy
             do {
                 try realm.write {
+                    editable.tags.removeAll()
                     tags.forEach { editable.tags[$0.key] = $0.value }
+                    editable.version = version
                 }
             } catch {
                 print("Error while writing tags")
             }
             return editable
         }
-
-        // Step 3: If not found, create from original
-        guard let original = getWay(id: intId, version: .original) else {
-            print("❌ Original not found")
-            return nil
-        }
-
-        let copy = StoredWay()
-        copy.id = original.id
-        copy.version = original.version
-        copy.timestamp = original.timestamp
-        
-        original.tags.forEach { entry in
-            copy.tags[entry.key] = entry.value
-        }
-        
-        copy.nodes.append(objectsIn: original.nodes)
-        copy.polyline.append(objectsIn: original.polyline)
-        copy.isOriginal = false
-        copy.generateCompoundId()
-
-        // Step 4: Apply the new tags to this new editable copy
-        tags.forEach { copy.tags[$0.key] = $0.value }
-
-        do {
-            try realm.write {
-                realm.add(copy)
-            }
-        } catch {
-            print("Error while saving editable copy")
-        }
-
-        return copy
+        return nil
     }
     
     
@@ -305,15 +274,16 @@ class DatabaseConnector {
      @param tags [String:String] map of the added tags
      @return StoredNode
      */
-    func addNodeTags(id: String, tags: [String: String]) -> StoredNode? {
-        let intId = Int(id) ?? -1
-        print("🟣 addNodeTags called for id: \(intId) with tags: \(tags)")
+    func addNodeTags(id: Int, tags: [String: String], version: Int) -> StoredNode? {
+        print("🟣 addNodeTags called for id: \(id) with tags: \(tags)")
 
-        if let editable = getNode(id: intId, version: .edited) {
+        if let editable = getNode(id: id, version: .original) {
             print("✏️ Editable node exists: \(editable.compoundId)")
             do {
                 try realm.write {
+                    editable.tags.removeAll()
                     tags.forEach { editable.tags[$0.key] = $0.value }
+                    editable.version = version
                 }
                 print("✅ Updated editable node.")
             } catch {
@@ -321,40 +291,7 @@ class DatabaseConnector {
             }
             return editable
         }
-
-        guard let original = getNode(id: intId, version: .original) else {
-            print("❌ Original node not found for id: \(intId)")
-            return nil
-        }
-
-        print("📄 Creating editable copy from original: \(original.compoundId)")
-
-        let copy = StoredNode()
-        copy.id = original.id
-        copy.version = original.version
-        copy.timestamp = original.timestamp
-        copy.point = original.point
-        copy.isOriginal = false
-        copy.generateCompoundId()
-
-        print("🛠️ New compoundId: \(copy.compoundId)")
-
-        original.tags.forEach { entry in
-            copy.tags[entry.key] = entry.value
-        }
-
-        tags.forEach { copy.tags[$0.key] = $0.value }
-
-        do {
-            try realm.write {
-                realm.add(copy)
-            }
-            print("✅ Editable node copy saved to DB: \(copy.compoundId)")
-        } catch {
-            print("❌ Error while saving editable node copy: \(error)")
-        }
-
-        return copy
+        return nil
     }
 
 

--- a/GoInfoGame/GoInfoGame/DataBase/DatabaseConnector.swift
+++ b/GoInfoGame/GoInfoGame/DataBase/DatabaseConnector.swift
@@ -369,14 +369,27 @@ class DatabaseConnector {
      - parameter tags [String:String] tags changed with this
      - Returns: An instance of `StoredChangeset`
         */
-    func createChangeset(id:String, type: StoredElementEnum, tags:[String:String]) -> StoredChangeset? {            
+    func createChangeset(id:Int, type: StoredElementEnum, originalTags:[String:String], tags:[String:String], version: Int, point: CLLocationCoordinate2D? = nil, nodes: List<Int64>? = nil) -> StoredChangeset? {
         let storedChangeset = StoredChangeset()
         storedChangeset.elementId = id
         storedChangeset.elementType = type
+        storedChangeset.version = version
+        if let point = point {
+            storedChangeset.point = point
+        }
+        if let nodes = nodes {
+            storedChangeset.nodes = nodes
+        }
+        
         storedChangeset.timestamp =  String(Date().timeIntervalSince1970)
         for tag in tags {
             storedChangeset.tags.setValue(tag.value, forKey: tag.key)
         }
+        
+        for tag in originalTags {
+            storedChangeset.originalTags.setValue(tag.value, forKey: tag.key)
+        }
+        
         do {
             try realm.write {
                 realm.add(storedChangeset)

--- a/GoInfoGame/GoInfoGame/Network/ApiManager.swift
+++ b/GoInfoGame/GoInfoGame/Network/ApiManager.swift
@@ -168,7 +168,7 @@ class ApiManager {
                 } catch {
                     print("Failed to decode data: \(error.localizedDescription)")
                     if let dataString = String(data: data, encoding: .utf8), !dataString.isEmpty {
-                        completion(.failure(APIError.custom("Not a valid JSON")))
+                        completion(.failure(APIError.custom("Not a valid JSON \(dataString)")))
                     } else {
                         completion(.failure(APIError.custom("Empty JSON")))
                     }

--- a/GoInfoGame/GoInfoGame/UI/InitialView/InitialView.swift
+++ b/GoInfoGame/GoInfoGame/UI/InitialView/InitialView.swift
@@ -135,6 +135,7 @@ struct WorkspacesListView: View {
                             VStack(spacing: 20) {
                                 ForEach(workspaces.filter({$0.type == "osw" && $0.externalAppAccess == 1}), id: \.id) { workspace in
                                     Button {
+                                        viewModel.checkAndDeleteWorkspaceDB(workspaceId: "\(workspace.id)")
                                         viewModel.fetchLongQuestsFor(workspaceId: "\(workspace.id)", completion: { success, errorMessage in
                                             if success {
                                                 self.shouldNavigateToMapView = true

--- a/GoInfoGame/GoInfoGame/UI/InitialView/InitialViewModel.swift
+++ b/GoInfoGame/GoInfoGame/UI/InitialView/InitialViewModel.swift
@@ -49,6 +49,17 @@ class InitialViewModel: ObservableObject {
     }
     }
     
+    func checkAndDeleteWorkspaceDB(workspaceId: String) {
+        if let existingWorkspaceId = KeychainManager.load(key: "workspaceID") {
+            if existingWorkspaceId != workspaceId {
+                print("User is changing the workpace. Delete all existing data from DB")
+                DatabaseConnector.shared.clearDB()
+            }
+        }
+        
+        
+    }
+    
     func fetchLongQuestsFor(workspaceId: String,completion: @escaping (Bool, String?) -> Void) {
         
         isLoading = true

--- a/GoInfoGame/GoInfoGame/UI/Map/MapView.swift
+++ b/GoInfoGame/GoInfoGame/UI/Map/MapView.swift
@@ -391,6 +391,11 @@ struct MapView: View {
             case .hideElement(let elementId, let elementName):
                 shouldShowPolyline = false
                 viewModel.hideQuest(elementId: elementId, elementName: elementName)
+            case .undoDone(let changesetId):
+                shouldShowPolyline = false
+                showAlert = true
+                alertMessage = "Changes reverted"
+                viewModel.refreshMapAfterUndoSumbit(storedChangesetId: changesetId)
             }
         }
         .onReceive(QuestsPublisher.shared.refreshQuest, perform: { _ in
@@ -474,6 +479,7 @@ public enum SheetDismissalScenario {
     case synced
     case failed(String)
     case hideElement(String, String)
+    case undoDone(String)
 }
 
 //TODO: Move to a new file

--- a/GoInfoGame/GoInfoGame/UI/Map/MapView.swift
+++ b/GoInfoGame/GoInfoGame/UI/Map/MapView.swift
@@ -405,11 +405,11 @@ struct MapView: View {
             HiddenQuestManager.shared.loadHiddenQuests()
             print("selected workspace",selectedWorkspace?.title ?? "")
             QuestsRepository.shared.loadLongQuests(from: "longQuestJson")
-            self.baseUrl = "https://osm.workspaces-stage.sidewalks.washington.edu"
-            let original = DatabaseConnector.shared.getNode(id: 43, version: .original)
-            let edited = DatabaseConnector.shared.getNode(id: 43, version: .edited)
-            print("ORIGINAL --->>>\(original)")
-            print("EDITED --->>>\(edited)")
+//            self.baseUrl = "https://osm.workspaces-stage.sidewalks.washington.edu"
+//            let original = DatabaseConnector.shared.getNode(id: 43, version: .original)
+//            let edited = DatabaseConnector.shared.getNode(id: 43, version: .edited)
+//            print("ORIGINAL --->>>\(original)")
+//            print("EDITED --->>>\(edited)")
         }
     }
     

--- a/GoInfoGame/GoInfoGame/UI/Map/MapView.swift
+++ b/GoInfoGame/GoInfoGame/UI/Map/MapView.swift
@@ -146,8 +146,8 @@ struct MapView: View {
                             },
                             onRemovePreview: {
                             },
-                            onRevert: { id, type in
-                                MapUndoManager.shared.undo(for: Int64(id), type: type)
+                            onRevert: { id in
+                                MapUndoManager.shared.undo(for: id)
                             }
                         )
                         .padding(.bottom, 24)

--- a/GoInfoGame/GoInfoGame/UI/Map/MapViewModel.swift
+++ b/GoInfoGame/GoInfoGame/UI/Map/MapViewModel.swift
@@ -158,6 +158,19 @@ class MapViewModel: ObservableObject {
       //  }
     }
     
+    // The item may have been already resolved or changed.
+    // Try and add the item to items
+    func refreshMapAfterUndoSumbit(storedChangesetId: String) {
+        print("Refreshing map after undo submit")
+        
+        if let newItem = AppQuestManager.shared.fetchQuestForChangeset(storedChangesetId: storedChangesetId) {
+            self.items.append(newItem)
+        } else {
+            print("No new item got")
+        }
+        
+    }
+    
     func hideQuest(elementId: String, elementName: String) {
         print(elementId)
         HiddenQuestManager.shared.hideQuest(elementId: elementId, elementName: elementName, items: &items)

--- a/GoInfoGame/GoInfoGame/UI/Profile/ProfileView.swift
+++ b/GoInfoGame/GoInfoGame/UI/Profile/ProfileView.swift
@@ -162,6 +162,8 @@ struct LoggedInView: View {
             _ = KeychainManager.delete(key: "refreshToken")
             UserDefaults.standard.removeObject(forKey: "accessToken_expire_in")
             UserDefaults.standard.removeObject(forKey: "accessToken_Generate")
+            // Removing all the data from database as well.
+            DatabaseConnector.shared.clearDB()
             accessToken = nil
         } label: {
             Text("LOGOUT")

--- a/GoInfoGame/GoInfoGame/UI/Utils/UndoButton.swift
+++ b/GoInfoGame/GoInfoGame/UI/Utils/UndoButton.swift
@@ -11,7 +11,7 @@ import osmparser
 struct UndoButton: View {
     var onPreview: (Int, ElementType) -> Void
     var onRemovePreview: () -> Void
-    var onRevert: (Int, ElementType) -> Void
+    var onRevert: (String) -> Void
 
     @State private var showSidebar = false
     @State private var undoItems: [UndoItem] = []
@@ -22,8 +22,8 @@ struct UndoButton: View {
         ZStack(alignment: .leading) {
             if showSidebar {
                 UndoSidebarView(
-                    onUndo: { id, type in
-                        onRevert(id, type)
+                    onUndo: { id in
+                        onRevert(id)
                         undoItems = MapUndoManager.shared.getUndoItems()
                         withAnimation { showSidebar = false }
                     },
@@ -65,7 +65,7 @@ struct UndoButton: View {
                     }
 
                 VStack(spacing: 16) {
-                    Text("\(item.type == .way ? "Way" : "Node") #\(item.elementId)")
+                    Text("\(item.type == .way ? "Way" : "Node") #\(String(item.elementId))")
                         .font(.headline)
 
                     if !item.changedKeys.isEmpty {
@@ -89,7 +89,7 @@ struct UndoButton: View {
                         Spacer()
 
                         Button("Revert") {
-                            onRevert(item.elementId, item.type)
+                            onRevert(item.id)
                             showUndoPopup = false
                             showSidebar = false
                         }

--- a/GoInfoGame/GoInfoGame/UI/Utils/UndoButton.swift
+++ b/GoInfoGame/GoInfoGame/UI/Utils/UndoButton.swift
@@ -98,6 +98,7 @@ struct UndoButton: View {
                         .padding(.vertical, 6)
                         .background(Color.red)
                         .cornerRadius(8)
+//                        .frame(width: 200)
                     }
                 }
                 .padding()
@@ -108,6 +109,16 @@ struct UndoButton: View {
             }
         }
     }
+}
+
+#Preview {
+    UndoButton(onPreview: { id, type in
+        
+    }, onRemovePreview: {
+         
+    }, onRevert: { changesetid in
+        
+    })
 }
 
 

--- a/GoInfoGame/GoInfoGame/UI/Utils/UndoSidebarView.swift
+++ b/GoInfoGame/GoInfoGame/UI/Utils/UndoSidebarView.swift
@@ -63,5 +63,15 @@ struct UndoSidebarView: View {
         .shadow(radius: 5)
     }
 }
+#Preview {
+    UndoSidebarView(
+        
+        onUndo: {_ in
+            
+        },
+        onClose: {},
+        onItemSelected: {_ in })
+    
+}
 
 

--- a/GoInfoGame/GoInfoGame/UI/Utils/UndoSidebarView.swift
+++ b/GoInfoGame/GoInfoGame/UI/Utils/UndoSidebarView.swift
@@ -7,12 +7,12 @@ struct UndoItem: Identifiable {
     let elementId: Int
     let type: ElementType
     let changedKeys: [String]
-    var id: String { "\(type)-\(elementId)" }
+    var id: String
 }
 
 struct UndoSidebarView: View {
     @State private var undoItems: [UndoItem] = []
-    var onUndo: (Int, ElementType) -> Void
+    var onUndo: (String) -> Void
     var onClose: () -> Void
     var onItemSelected: (UndoItem) -> Void
 

--- a/GoInfoGame/GoInfoGame/data/DatasyncManager.swift
+++ b/GoInfoGame/GoInfoGame/data/DatasyncManager.swift
@@ -111,10 +111,10 @@ class DatasyncManager {
             print("📤 Syncing node ID: \(node.id)")
             let payload = node.asOSMNode()
             do {
-                let isFinished = try await syncNode(node: payload)
-                if isFinished {
+                let status = try await syncNode(node: payload, exclude_gig_tags: exclude_gig_tags)
+                if status.result {
                     DispatchQueue.main.async {
-                        self.dbInstance.assignChangesetId(obj: key, changesetId: 0)
+                        self.dbInstance.assignChangesetId(obj: key, changesetId: 0, updatedVersion: status.version)
                     }
                     print("✅ Node sync finished: \(payload.id)")
                 } else {
@@ -132,10 +132,10 @@ class DatasyncManager {
             print("📤 Syncing way ID: \(way.id)")
             let payload = way.asOSMWay()
             do {
-                let isFinished = try await syncWay(way: payload, exclude_gig_tags: exclude_gig_tags)
-                if isFinished {
+                let status = try await syncWay(way: payload, exclude_gig_tags: exclude_gig_tags)
+                if status.result {
                     DispatchQueue.main.async {
-                        self.dbInstance.assignChangesetId(obj: key, changesetId: 0)
+                        self.dbInstance.assignChangesetId(obj: key, changesetId: 0, updatedVersion: status.version)
                     }
                     print("✅ Way sync finished: \(payload.id)")
                 } else {
@@ -252,7 +252,7 @@ class DatasyncManager {
     }
 
     // utility function to act as substitute for osmConnection functions
-    func updateWay(way: OSMWay, exclude_gig_tags: Bool = false) async throws -> Int {
+    func updateWay(way: OSMWay, exclude_gig_tags: Bool) async throws -> Int {
         var localWay = way
         let wayBodyString = localWay.toPayload(exclude_gig_tags: exclude_gig_tags)
         let changesetUploadBody = "<osmChange version=\"0.6\" generator=\"GIG Change generator\">" + wayBodyString + "</osmChange>"
@@ -372,14 +372,14 @@ class DatasyncManager {
                 print(localWay)
                 print("Merged way")
                 print(mergedWay)
-                return try await updateWay(way: mergedWay)
+                return try await updateWay(way: mergedWay, exclude_gig_tags: exclude_gig_tags)
             default:
                 throw error
             }
         }
     }
 
-    func updateNode2(node: OSMNode) async throws -> Int {
+    func updateNode2(node: OSMNode, exclude_gig_tags: Bool) async throws -> Int {
         var localNode = node
         
         let nodeId = "\(localNode.id)"
@@ -387,7 +387,7 @@ class DatasyncManager {
 
         var updatedResult: Int = -1
         do {
-             updatedResult = try await updateNode(node: localNode)
+             updatedResult = try await updateNode(node: localNode, exclude_gig_tags: exclude_gig_tags)
             return updatedResult
             
         } catch let error as APIError {
@@ -500,7 +500,7 @@ class DatasyncManager {
             Syncs the node along with the updated
      */
     @MainActor
-    func syncNode(node: OSMNode) async throws -> Bool {
+    func syncNode(node: OSMNode, exclude_gig_tags: Bool) async throws -> (result:Bool, version: Int) {
         var localNode = node
         
         SyncLogger.shared.logStep("Open Changeset")
@@ -513,7 +513,7 @@ class DatasyncManager {
             localNode.changeset = changesetID
             
             //Step 2: Update Node
-            let newVersion = try await updateNode2(node: localNode)
+            let newVersion = try await updateNode2(node: localNode, exclude_gig_tags: exclude_gig_tags)
             localNode.version = newVersion
             DispatchQueue.main.async {
                 self.dbInstance.updateNodeVersion(nodeId: String(localNode.id), version: newVersion)
@@ -521,7 +521,8 @@ class DatasyncManager {
             
             //Stepp 3:Close changeset
             SyncLogger.shared.logStep("Close Changeset")
-           return try await closeChangeset(id: String(changesetID))
+            let result = try await closeChangeset(id: String(changesetID))
+            return (result, newVersion)
         
         } catch {
             print("Failed to open changeset:", error.localizedDescription)
@@ -551,7 +552,7 @@ class DatasyncManager {
     }
     
     @MainActor
-    func syncWay(way: OSMWay, exclude_gig_tags: Bool = false) async throws -> Bool {
+    func syncWay(way: OSMWay, exclude_gig_tags: Bool = false) async throws -> (result: Bool, version: Int) {
         var localWay = way
         
         do {
@@ -567,7 +568,8 @@ class DatasyncManager {
             DispatchQueue.main.async {
                 self.dbInstance.updateWayVersion(wayId: String(localWay.id), version: newVersion)
             }
-            return try await closeChangeset(id: String(changesetID))
+            let result = try await closeChangeset(id: String(changesetID))
+            return  (result, newVersion)
             
         } catch {
             throw error

--- a/GoInfoGame/GoInfoGame/data/DatasyncManager.swift
+++ b/GoInfoGame/GoInfoGame/data/DatasyncManager.swift
@@ -68,13 +68,13 @@ class DatasyncManager {
             let intId = Int($0.elementId) ?? -1
             switch $0.elementType {
             case .way:
-                let exists = self.dbInstance.getWay(id: intId, version: .edited) != nil
+                let exists = self.dbInstance.getWay(id: intId, version: .original) != nil
                 if !exists {
                     print("⚠️ Edited way not found for ID: \(intId)")
                 }
                 return exists
             case .node:
-                let exists = self.dbInstance.getNode(id: intId, version: .edited) != nil
+                let exists = self.dbInstance.getNode(id: intId, version: .original) != nil
                 if !exists {
                     print("⚠️ Edited node not found for ID: \(intId)")
                 }
@@ -86,17 +86,17 @@ class DatasyncManager {
 
         print("📦 Found \(validChangesets.count) unsynced changesets with valid edits")
 
-        var nodesToSync: [String: StoredNode] = [:]
-        var waysToSync: [String: StoredWay] = [:]
+        var nodesToSync: [String: StoredChangeset] = [:]
+        var waysToSync: [String: StoredChangeset] = [:]
 
         for cs in validChangesets {
             let intId = Int(cs.elementId) ?? -1
             if cs.elementType == .node,
-               let node = dbInstance.getNode(id: intId, version: .edited) {
-                nodesToSync[cs.id] = node
+               let node = dbInstance.getNode(id: intId, version: .original) {
+                nodesToSync[cs.id] = cs
             } else if cs.elementType == .way,
-                      let way = dbInstance.getWay(id: intId, version: .edited) {
-                waysToSync[cs.id] = way
+                      let way = dbInstance.getWay(id: intId, version: .original) {
+                waysToSync[cs.id] = cs
             }
         }
 

--- a/GoInfoGame/GoInfoGame/data/DatasyncManager.swift
+++ b/GoInfoGame/GoInfoGame/data/DatasyncManager.swift
@@ -277,6 +277,11 @@ class DatasyncManager {
                     localWay.tags.forEach { (key: String, value: String) in
                         localWay.tags[key] = value
                     }
+                    let id = localWay.id
+                    let tags = localWay.tags
+                    DispatchQueue.main.async {
+                        _ = DatabaseConnector.shared.addWayTags(id: id, tags: tags, version: newVersion)
+                    }
                     continuation.resume(returning: newVersion)
 
                 case .failure(let error):
@@ -320,6 +325,9 @@ class DatasyncManager {
                     }
                     updatedNode.version = newVersion
                     SyncLogger.shared.logStep("Node Updated ----\(updatedNode.tags)")
+                    DispatchQueue.main.async {
+                        _ = DatabaseConnector.shared.addNodeTags(id: updatedNode.id, tags: updatedNode.tags, version: newVersion)
+                    }
                     continuation.resume(returning: newVersion)
                 case .failure(let error):
                     print(error)

--- a/GoInfoGame/GoInfoGame/data/DatasyncManager.swift
+++ b/GoInfoGame/GoInfoGame/data/DatasyncManager.swift
@@ -111,7 +111,7 @@ class DatasyncManager {
             print("📤 Syncing node ID: \(node.id)")
             let payload = node.asOSMNode()
             do {
-                let status = try await syncNode(node: payload, exclude_gig_tags: exclude_gig_tags)
+                let status = try await syncNode(node: payload, exclude_gig_tags: exclude_gig_tags, editedTags: node.tags.toDictionary())
                 if status.result {
                     DispatchQueue.main.async {
                         self.dbInstance.assignChangesetId(obj: key, changesetId: 0, updatedVersion: status.version)
@@ -132,7 +132,7 @@ class DatasyncManager {
             print("📤 Syncing way ID: \(way.id)")
             let payload = way.asOSMWay()
             do {
-                let status = try await syncWay(way: payload, exclude_gig_tags: exclude_gig_tags)
+                let status = try await syncWay(way: payload, exclude_gig_tags: exclude_gig_tags, editedTags: way.tags.toDictionary())
                 if status.result {
                     DispatchQueue.main.async {
                         self.dbInstance.assignChangesetId(obj: key, changesetId: 0, updatedVersion: status.version)
@@ -288,7 +288,7 @@ class DatasyncManager {
     }
   
     // utility function to act as substitute for osmConnection functions
-    func updateNode(node: OSMNode, exclude_gig_tags: Bool = false) async throws -> Int {
+    func updateNode(node: OSMNode, exclude_gig_tags: Bool) async throws -> Int {
         var localNode = node
         let nodeBodyString = localNode.toPayload(exclude_gig_tags: exclude_gig_tags)
         let changesetUploadBody = "<osmChange version=\"0.6\" generator=\"GIG Change generator\">" + nodeBodyString + "</osmChange>"
@@ -356,7 +356,7 @@ class DatasyncManager {
         }
     }
 
-    func updateWay2(way: OSMWay, exclude_gig_tags: Bool = false) async throws -> Int {
+    func updateWay2(way: OSMWay, exclude_gig_tags: Bool, editedTags: [String : String]) async throws -> Int {
         var localWay = way
         let wayId = "\(localWay.id)"
         var updatedResult: Int = -1
@@ -367,19 +367,24 @@ class DatasyncManager {
             switch error {
             case .conflict:
                 let updatedWay = try await fetchway2(wayId: wayId)
-                var mergedWay = self.mergeWays(localWay: localWay, latestWay: updatedWay)
-                print("Local way")
-                print(localWay)
-                print("Merged way")
-                print(mergedWay)
-                return try await updateWay(way: mergedWay, exclude_gig_tags: exclude_gig_tags)
+                if let mergedWay = self.mergeWays(localWay: localWay, latestWay: updatedWay, exclude_gig_tags: exclude_gig_tags, editedTags: editedTags) {
+                    print("Local way")
+                    print(localWay)
+                    print("Merged way")
+                    print(mergedWay)
+                    return try await updateWay(way: mergedWay, exclude_gig_tags: exclude_gig_tags)
+                } else {
+                    print("Undo operation is not possible")
+                    return updatedWay.version
+                }
+                
             default:
                 throw error
             }
         }
     }
 
-    func updateNode2(node: OSMNode, exclude_gig_tags: Bool) async throws -> Int {
+    func updateNode2(node: OSMNode, exclude_gig_tags: Bool, editedTags: [String : String]) async throws -> Int {
         var localNode = node
         
         let nodeId = "\(localNode.id)"
@@ -396,13 +401,18 @@ class DatasyncManager {
                 SyncLogger.shared.logStep("Fetching node due to conflict")
                 let fetchedResult = try await fetchNode2(nodeId: "\(localNode.id)")
                 
-                var mergedNode = self.mergeNodes(localNode: localNode, latestNode: fetchedResult)
-                print("Local Node:")
-                print(localNode)
-                print("Merged Node:")
-                print(mergedNode)
-                SyncLogger.shared.logStep("Nodes fetched and merged")
-                return try await updateNode(node: mergedNode)
+                if let mergedNode = self.mergeNodes(localNode: localNode, latestNode: fetchedResult, exclude_gig_tags: exclude_gig_tags, editedTags: editedTags) {
+                    print("Local Node:")
+                    print(localNode)
+                    print("Merged Node:")
+                    print(mergedNode)
+                    SyncLogger.shared.logStep("Nodes fetched and merged")
+                    return try await updateNode(node: mergedNode, exclude_gig_tags: exclude_gig_tags)
+                } else {
+                    print("Undo operation is not possible")
+                    return fetchedResult.version
+                }
+                
             default:
                 throw error
             }
@@ -411,19 +421,78 @@ class DatasyncManager {
     }
 
 
-    func mergeWays(localWay: OSMWay, latestWay: OSMWay) -> OSMWay {
+    func mergeTagsForUndo(originalTags: [String : String], edited: [String : String], serverTags: [String : String]) -> [String : String]? {
+        var resultTags: [String: String] = [:]
+        print("mergeTagsForUndo originalTags \(originalTags) \n edited \(edited) \n serverTags \(serverTags)")
+        for (key, value) in edited {
+            if let orgValue = originalTags[key] {
+                if let serverVal = serverTags[key] {
+                    if orgValue != serverVal, value != serverVal {
+                        return nil
+                    }
+                } else {
+                    return nil
+                }
+            } else {
+                if let serverVal = serverTags[key], value != serverVal {
+                    return nil
+                }
+            }
+        }
+        
+        let unionKeys = Set(originalTags.keys).union(Set(serverTags.keys))
+        
+        for key in unionKeys {
+            if let serverValue = serverTags[key] {
+                if let editValue = edited[key] {
+                    if editValue == serverValue {
+                        if let originalValue = originalTags[key]  {
+                            resultTags[key] = originalValue
+                            continue
+                        }
+                        continue
+                    }
+                }
+                resultTags[key] = serverValue
+            } else {
+                resultTags.removeValue(forKey: key)
+            }
+        }
+        resultTags.removeValue(forKey: "ext:gig_last_updated")
+        resultTags.removeValue(forKey: "ext:gig_complete")
+        print("mergeTagsForUndo resultTags \(resultTags)")
+        return resultTags
+    }
+    
+    func mergeWays(localWay: OSMWay, latestWay: OSMWay, exclude_gig_tags: Bool, editedTags: [String : String]) -> OSMWay? {
           var mergedWay = latestWay
-          for (key, value) in localWay.tags {
-              mergedWay.tags[key] = value
-          }
+        if exclude_gig_tags {
+            if let resultTags = mergeTagsForUndo(originalTags: localWay.tags, edited: editedTags, serverTags: latestWay.tags) {
+                mergedWay.tags = resultTags
+            } else {
+                return nil
+            }
+        } else {
+            for (key, value) in localWay.tags {
+                mergedWay.tags[key] = value
+            }
+        }
           mergedWay.changeset = localWay.changeset
           return mergedWay
       }
     
-    func mergeNodes(localNode: OSMNode, latestNode: OSMNode) -> OSMNode {
+    func mergeNodes(localNode: OSMNode, latestNode: OSMNode, exclude_gig_tags: Bool, editedTags: [String : String]) -> OSMNode? {
         var mergedNode = latestNode
-        for (key, value) in localNode.tags {
-            mergedNode.tags[key] = value
+        if exclude_gig_tags {
+            if let resultTags = mergeTagsForUndo(originalTags: localNode.tags, edited: editedTags, serverTags: latestNode.tags) {
+                mergedNode.tags = resultTags
+            } else {
+                return nil
+            }
+        } else {
+            for (key, value) in localNode.tags {
+                mergedNode.tags[key] = value
+            }
         }
         mergedNode.changeset = localNode.changeset
         return mergedNode
@@ -500,7 +569,7 @@ class DatasyncManager {
             Syncs the node along with the updated
      */
     @MainActor
-    func syncNode(node: OSMNode, exclude_gig_tags: Bool) async throws -> (result:Bool, version: Int) {
+    func syncNode(node: OSMNode, exclude_gig_tags: Bool, editedTags: [String : String]) async throws -> (result:Bool, version: Int) {
         var localNode = node
         
         SyncLogger.shared.logStep("Open Changeset")
@@ -513,7 +582,7 @@ class DatasyncManager {
             localNode.changeset = changesetID
             
             //Step 2: Update Node
-            let newVersion = try await updateNode2(node: localNode, exclude_gig_tags: exclude_gig_tags)
+            let newVersion = try await updateNode2(node: localNode, exclude_gig_tags: exclude_gig_tags, editedTags: editedTags)
             localNode.version = newVersion
             DispatchQueue.main.async {
                 self.dbInstance.updateNodeVersion(nodeId: String(localNode.id), version: newVersion)
@@ -552,7 +621,7 @@ class DatasyncManager {
     }
     
     @MainActor
-    func syncWay(way: OSMWay, exclude_gig_tags: Bool = false) async throws -> (result: Bool, version: Int) {
+    func syncWay(way: OSMWay, exclude_gig_tags: Bool, editedTags: [String : String]) async throws -> (result: Bool, version: Int) {
         var localWay = way
         
         do {
@@ -561,7 +630,7 @@ class DatasyncManager {
             
             localWay.changeset = changesetID
             
-            let newVersion = try await updateWay2(way: localWay, exclude_gig_tags: exclude_gig_tags)
+            let newVersion = try await updateWay2(way: localWay, exclude_gig_tags: exclude_gig_tags, editedTags: editedTags)
             
             localWay.version = newVersion
             

--- a/GoInfoGame/GoInfoGame/data/DatasyncManager.swift
+++ b/GoInfoGame/GoInfoGame/data/DatasyncManager.swift
@@ -278,7 +278,15 @@ class DatasyncManager {
                         localWay.tags[key] = value
                     }
                     let id = localWay.id
-                    let tags = localWay.tags
+                    var tags = localWay.tags
+                    // The gig tags are not added into the db when pushing directly
+                    // Adding them forcibly here.
+                    if (!exclude_gig_tags) {
+                        let gig_internal_tags = localWay.fetchInternalGigTags()
+                        gig_internal_tags.forEach { (key: String, value: String) in
+                            tags[key] = value
+                        }
+                    }
                     DispatchQueue.main.async {
                         _ = DatabaseConnector.shared.addWayTags(id: id, tags: tags, version: newVersion)
                     }
@@ -324,8 +332,18 @@ class DatasyncManager {
                         updatedNode.tags[key] = value
                     }
                     updatedNode.version = newVersion
+                    
+                    // Gig tags are not added to DB when pushing changes
+                    // those are added manually here
+                    if (!exclude_gig_tags) {
+                        let gig_internal_tags = updatedNode.fetchInternalGigTags()
+                        gig_internal_tags.forEach { (key: String, value: String) in
+                            updatedNode.tags[key] = value
+                        }
+                    }
                     SyncLogger.shared.logStep("Node Updated ----\(updatedNode.tags)")
                     DispatchQueue.main.async {
+                        
                         _ = DatabaseConnector.shared.addNodeTags(id: updatedNode.id, tags: updatedNode.tags, version: newVersion)
                     }
                     continuation.resume(returning: newVersion)
@@ -418,6 +436,8 @@ class DatasyncManager {
                     return try await updateNode(node: mergedNode, exclude_gig_tags: exclude_gig_tags)
                 } else {
                     print("Undo operation is not possible")
+                    // update the original node with the server node.
+                    // FIXME: this is not done. Need to do something.
                     return fetchedResult.version
                 }
                 

--- a/GoInfoGame/GoInfoGame/quests/QuestProtocols.swift
+++ b/GoInfoGame/GoInfoGame/quests/QuestProtocols.swift
@@ -37,12 +37,35 @@ class QuestBase {
     
    private var elementSubmittingToPOSM: ElementSubmittingToPOSM?
     
+    func updateUndoTags(changeSet: StoredChangeset) {
+        // Convert from ElementType enum to StoredElementEnum
+        Task.detached(operation: { @MainActor in
+            let storedElementType: StoredElementEnum = changeSet.elementType
+            do {
+                var result: (result: Bool, version: Int) = (false, -1)
+                switch storedElementType {
+                case .node:
+                    result = try await DatasyncManager.shared.syncNode(node: changeSet.asOSMNode(isUndo: true), exclude_gig_tags: true)
+                case .way:
+                    result = try await DatasyncManager.shared.syncWay(way: changeSet.asOSMWay(isUndo: true), exclude_gig_tags: true)
+                case .unknown:
+                    print("❌ Undo failed: Element type not found")
+                }
+            }
+            catch {
+                print("❌ Undo failed: \(error)")
+            }
+        })
+    }
+    
     // Add a custom implementation
     
    public func updateTags(id: Int64, tags:[String:String], type: ElementType, exclude_gig_tags: Bool = false) {
        
-       MapUndoManager.shared.updateTagsHandler = { [weak self] id, tags, type in
-           self?.updateTags(id: id, tags: tags, type: type, exclude_gig_tags: true)
+       MapUndoManager.shared.updateTagsHandler = { [weak self] changeset in
+           guard let changeSet = changeset else { return }
+           
+           self?.updateUndoTags(changeSet: changeSet)
        }
        
        

--- a/GoInfoGame/GoInfoGame/quests/QuestProtocols.swift
+++ b/GoInfoGame/GoInfoGame/quests/QuestProtocols.swift
@@ -48,6 +48,7 @@ class QuestBase {
     func updateUndoTags(changeSet: StoredChangeset) {
         // Convert from ElementType enum to StoredElementEnum
         Task.detached(operation: { @MainActor in
+            MapViewPublisher.shared.dismissSheet.send(.syncing)
             let storedElementType: StoredElementEnum = changeSet.elementType
             let changesetId = changeSet.id
             do {
@@ -64,7 +65,9 @@ class QuestBase {
                 DispatchQueue.main.async {
                     _ = DatabaseConnector.shared.updateChangesetWithUndoResultSuccess(obj: changesetId)
                 }
-                
+                MapViewPublisher.shared.dismissSheet.send(.synced)
+//                MapViewPublisher.shared.dismissSheet.send(.submitted(""))
+                MapViewPublisher.shared.dismissSheet.send(.undoDone(changesetId))
             }
             catch {
                 print("❌ Undo failed: \(error)")

--- a/GoInfoGame/GoInfoGame/quests/QuestProtocols.swift
+++ b/GoInfoGame/GoInfoGame/quests/QuestProtocols.swift
@@ -45,9 +45,9 @@ class QuestBase {
                 var result: (result: Bool, version: Int) = (false, -1)
                 switch storedElementType {
                 case .node:
-                    result = try await DatasyncManager.shared.syncNode(node: changeSet.asOSMNode(isUndo: true), exclude_gig_tags: true)
+                    result = try await DatasyncManager.shared.syncNode(node: changeSet.asOSMNode(isUndo: true), exclude_gig_tags: true, editedTags: changeSet.tags.toDictionary())
                 case .way:
-                    result = try await DatasyncManager.shared.syncWay(way: changeSet.asOSMWay(isUndo: true), exclude_gig_tags: true)
+                    result = try await DatasyncManager.shared.syncWay(way: changeSet.asOSMWay(isUndo: true), exclude_gig_tags: true, editedTags: changeSet.tags.toDictionary())
                 case .unknown:
                     print("❌ Undo failed: Element type not found")
                 }

--- a/GoInfoGame/GoInfoGame/quests/QuestProtocols.swift
+++ b/GoInfoGame/GoInfoGame/quests/QuestProtocols.swift
@@ -71,6 +71,7 @@ class QuestBase {
             }
             catch {
                 print("❌ Undo failed: \(error)")
+                MapViewPublisher.shared.dismissSheet.send(.failed("Failed to Undo changes. Please try again"))
             }
         })
     }

--- a/GoInfoGame/GoInfoGame/quests/QuestProtocols.swift
+++ b/GoInfoGame/GoInfoGame/quests/QuestProtocols.swift
@@ -41,6 +41,7 @@ class QuestBase {
         // Convert from ElementType enum to StoredElementEnum
         Task.detached(operation: { @MainActor in
             let storedElementType: StoredElementEnum = changeSet.elementType
+            let changesetId = changeSet.id
             do {
                 var result: (result: Bool, version: Int) = (false, -1)
                 switch storedElementType {
@@ -51,6 +52,11 @@ class QuestBase {
                 case .unknown:
                     print("❌ Undo failed: Element type not found")
                 }
+                print("undo result \(result)")
+                DispatchQueue.main.async {
+                    _ = DatabaseConnector.shared.updateChangesetWithUndoResultSuccess(obj: changesetId)
+                }
+                
             }
             catch {
                 print("❌ Undo failed: \(error)")

--- a/GoInfoGame/GoInfoGame/quests/QuestProtocols.swift
+++ b/GoInfoGame/GoInfoGame/quests/QuestProtocols.swift
@@ -48,16 +48,20 @@ class QuestBase {
        
        // Convert from ElementType enum to StoredElementEnum
        let storedElementType: StoredElementEnum = type == .way ? .way : .node
-       let storedId = String(id)
-       // Create a changeset
-       _ = DatabaseConnector.shared.createChangeset(id: storedId, type: storedElementType, tags: tags)
+       
        switch (storedElementType){
        case .way:
            elementSubmittingToPOSM = .way
-          _ = DatabaseConnector.shared.addWayTags(id: storedId, tags: tags)
+//          _ = DatabaseConnector.shared.addWayTags(id: storedId, tags: tags)
+           let way =  DatabaseConnector.shared.getWay(id: Int(id), version: .original)!
+           // Create a changeset
+           _ = DatabaseConnector.shared.createChangeset(id: Int(id), type: storedElementType, originalTags: way.tags.toDictionary(), tags: tags, version: way.version, nodes: way.nodes)
        case .node:
            elementSubmittingToPOSM = .node
-          _ = DatabaseConnector.shared.addNodeTags(id: storedId, tags: tags)
+//          _ = DatabaseConnector.shared.addNodeTags(id: storedId, tags: tags)
+           let node =  DatabaseConnector.shared.getNode(id: Int(id), version: .original)!
+           // Create a changeset
+           _ = DatabaseConnector.shared.createChangeset(id: Int(id), type: storedElementType, originalTags: node.tags.toDictionary(), tags: tags, version: node.version, point: node.point)
        case .unknown:
            print("Unknown Stored element type received")
        }

--- a/GoInfoGame/GoInfoGame/quests/QuestProtocols.swift
+++ b/GoInfoGame/GoInfoGame/quests/QuestProtocols.swift
@@ -37,6 +37,14 @@ class QuestBase {
     
    private var elementSubmittingToPOSM: ElementSubmittingToPOSM?
     
+    init () {
+        MapUndoManager.shared.updateTagsHandler = { [weak self] changeset in
+            guard let changeSet = changeset else { return }
+            
+            self?.updateUndoTags(changeSet: changeSet)
+        }
+    }
+    
     func updateUndoTags(changeSet: StoredChangeset) {
         // Convert from ElementType enum to StoredElementEnum
         Task.detached(operation: { @MainActor in
@@ -67,13 +75,6 @@ class QuestBase {
     // Add a custom implementation
     
    public func updateTags(id: Int64, tags:[String:String], type: ElementType, exclude_gig_tags: Bool = false) {
-       
-       MapUndoManager.shared.updateTagsHandler = { [weak self] changeset in
-           guard let changeSet = changeset else { return }
-           
-           self?.updateUndoTags(changeSet: changeSet)
-       }
-       
        
        // Convert from ElementType enum to StoredElementEnum
        let storedElementType: StoredElementEnum = type == .way ? .way : .node
@@ -106,10 +107,6 @@ class QuestBase {
                switch success {
                case .success(let success):
                    if success {
-                       if MapUndoManager.shared.isUndoInProgress {
-                           MapUndoManager.shared.finalizeSuccessfulSubmit(id: Int(id), type: type)
-                           MapUndoManager.shared.isUndoInProgress = false
-                       }
 
                        MapViewPublisher.shared.dismissSheet.send(.submitted("\(id)"))
                    }

--- a/GoInfoGame/GoInfoGame/quests/QuestUndoManager.swift
+++ b/GoInfoGame/GoInfoGame/quests/QuestUndoManager.swift
@@ -89,36 +89,15 @@ class MapUndoManager {
         }
     }
 
-
-
-
-    func fetchUndoItems() -> [UndoItem] {
-        var items: [UndoItem] = []
-        
-        
-        
-        
-        return items
-        
-    }
-
     
     func getUndoItems() -> [UndoItem] {
         var items: [UndoItem] = []
 
-        let editedNodes = realm.objects(StoredNode.self).filter("isOriginal == false")
+        let editedNodes = realm.objects(StoredChangeset.self).filter("changesetId == 0")
         for edited in editedNodes {
             let keys = Array(edited.tags.keys)
             if !keys.isEmpty {
-                items.append(UndoItem(elementId: edited.id, type: .node, changedKeys: keys))
-            }
-        }
-
-        let editedWays = realm.objects(StoredWay.self).filter("isOriginal == false")
-        for edited in editedWays {
-            let keys = Array(edited.tags.keys)
-            if !keys.isEmpty {
-                items.append(UndoItem(elementId: edited.id, type: .way, changedKeys: keys))
+                items.append(UndoItem(elementId: edited.elementId, type: edited.elementType.elementType(), changedKeys: keys))
             }
         }
 

--- a/GoInfoGame/GoInfoGame/quests/QuestUndoManager.swift
+++ b/GoInfoGame/GoInfoGame/quests/QuestUndoManager.swift
@@ -38,7 +38,7 @@ class MapUndoManager {
     func getUndoItems() -> [UndoItem] {
         var items: [UndoItem] = []
 
-        let editedNodes = realm.objects(StoredChangeset.self).filter("changesetId == 0")
+        let editedNodes = realm.objects(StoredChangeset.self).filter("changesetId == 0 && isUndoCompleted == false")
         for edited in editedNodes {
             let keys = Array(edited.tags.keys)
             if !keys.isEmpty {

--- a/GoInfoGame/GoInfoGame/quests/QuestUndoManager.swift
+++ b/GoInfoGame/GoInfoGame/quests/QuestUndoManager.swift
@@ -20,73 +20,18 @@ class MapUndoManager {
         realm = try! Realm()
     }
 
-    var updateTagsHandler: ((_ id: Int64, _ tags: [String: String], _ type: ElementType) -> Void)?
+    var updateTagsHandler: ((_ changeset: StoredChangeset?) -> Void)?
 
     func undo(for id: Int64, type: ElementType) {
         MapUndoManager.shared.isUndoInProgress = true
 
-        switch type {
-        case .way:
-            guard let original = DatabaseConnector.shared.getWay(id: Int(id), version: .original),
-                  let edited = DatabaseConnector.shared.getWay(id: Int(id), version: .edited) else {
-                print("❌ Undo failed: Way not found")
-                return
-            }
-
-            do {
-                try realm.write {
-                    edited.tags.removeAll()
-
-                    for entry in original.tags {
-                        let key = entry.key
-                        let value = entry.value
-                        if key != "ext:gig_complete", key != "ext:gig_last_updated" {
-                            edited.tags[key] = value
-                        }
-                    }
-
-                    edited.polyline.removeAll()
-                    edited.polyline.append(objectsIn: original.polyline)
-
-                    edited.nodes.removeAll()
-                    edited.nodes.append(objectsIn: original.nodes)
-                }
-            } catch {
-                print("❌ Realm write failed during undo (way): \(error)")
-            }
-
-            updateTagsHandler?(id, edited.tags.toDictionary(), .way)
-
-        case .node:
-            guard let original = DatabaseConnector.shared.getNode(id: Int(id), version: .original),
-                  let edited = DatabaseConnector.shared.getNode(id: Int(id), version: .edited) else {
-                print("❌ Undo failed: Node not found")
-                return
-            }
-
-            do {
-                try realm.write {
-                    edited.tags.removeAll()
-
-                    for entry in original.tags {
-                        let key = entry.key
-                        let value = entry.value
-                        if key != "ext:gig_complete", key != "ext:gig_last_updated" {
-                            edited.tags[key] = value
-                        }
-                    }
-
-                    edited.point = original.point
-                }
-            } catch {
-                print("❌ Realm write failed during undo (node): \(error)")
-            }
-
-            updateTagsHandler?(id, edited.tags.toDictionary(), .node)
-
-        default:
-            print("Unknown element type")
+        guard let changeSet = DatabaseConnector.shared.getChangeset(for: id, type: type) else {
+            print("❌ Undo failed: Element not found")
+            updateTagsHandler?(nil)
+            return
         }
+
+        updateTagsHandler?(changeSet)
     }
 
     

--- a/GoInfoGame/GoInfoGame/quests/QuestUndoManager.swift
+++ b/GoInfoGame/GoInfoGame/quests/QuestUndoManager.swift
@@ -14,18 +14,14 @@ class MapUndoManager {
     
     private let realm: Realm
     
-    var isUndoInProgress: Bool = false
-
     private init() {
         realm = try! Realm()
     }
 
     var updateTagsHandler: ((_ changeset: StoredChangeset?) -> Void)?
 
-    func undo(for id: Int64, type: ElementType) {
-        MapUndoManager.shared.isUndoInProgress = true
-
-        guard let changeSet = DatabaseConnector.shared.getChangeset(for: id, type: type) else {
+    func undo(for id: String) {
+        guard let changeSet = DatabaseConnector.shared.getChangeset(for: id) else {
             print("❌ Undo failed: Element not found")
             updateTagsHandler?(nil)
             return
@@ -42,7 +38,7 @@ class MapUndoManager {
         for edited in editedNodes {
             let keys = Array(edited.tags.keys)
             if !keys.isEmpty {
-                items.append(UndoItem(elementId: edited.elementId, type: edited.elementType.elementType(), changedKeys: keys))
+                items.append(UndoItem(elementId: edited.elementId, type: edited.elementType.elementType(), changedKeys: keys, id: edited.id))
             }
         }
 
@@ -51,36 +47,36 @@ class MapUndoManager {
 }
 
 extension MapUndoManager {
-    func finalizeSuccessfulSubmit(id: Int, type: ElementType) {
-        let realm = try! Realm()
-
-        try? realm.write {
-            switch type {
-            case .way:
-                if let original = DatabaseConnector.shared.getWay(id: id, version: .original) {
-                    original.tags["ext:gig_complete"] = "yes"
-                }
-                if let edited = DatabaseConnector.shared.getWay(id: id, version: .edited) {
-                    realm.delete(edited)
-                }
-
-            case .node:
-                if let original = DatabaseConnector.shared.getNode(id: id, version: .original) {
-                    original.tags["ext:gig_complete"] = "yes"
-                }
-                if let edited = DatabaseConnector.shared.getNode(id: id, version: .edited) {
-                    realm.delete(edited)
-                }
-
-            default:
-                break
-            }
-
-            if let changeset = DatabaseConnector.shared.getChangeset(for: Int64(id), type: type) {
-                realm.delete(changeset)
-            }
-        }
-    }
+//    func finalizeSuccessfulSubmit(id: Int, type: ElementType) {
+//        let realm = try! Realm()
+//
+//        try? realm.write {
+//            switch type {
+//            case .way:
+//                if let original = DatabaseConnector.shared.getWay(id: id, version: .original) {
+//                    original.tags["ext:gig_complete"] = "yes"
+//                }
+//                if let edited = DatabaseConnector.shared.getWay(id: id, version: .edited) {
+//                    realm.delete(edited)
+//                }
+//
+//            case .node:
+//                if let original = DatabaseConnector.shared.getNode(id: id, version: .original) {
+//                    original.tags["ext:gig_complete"] = "yes"
+//                }
+//                if let edited = DatabaseConnector.shared.getNode(id: id, version: .edited) {
+//                    realm.delete(edited)
+//                }
+//
+//            default:
+//                break
+//            }
+//
+//            if let changeset = DatabaseConnector.shared.getChangeset(for: Int64(id), type: type) {
+//                realm.delete(changeset)
+//            }
+//        }
+//    }
 
 
 }

--- a/GoInfoGame/GoInfoGame/quests/QuestUndoManager.swift
+++ b/GoInfoGame/GoInfoGame/quests/QuestUndoManager.swift
@@ -46,6 +46,7 @@ class MapUndoManager {
     }
 }
 
+//FIXME: This is completely removed
 extension MapUndoManager {
 //    func finalizeSuccessfulSubmit(id: Int, type: ElementType) {
 //        let realm = try! Realm()
@@ -93,6 +94,7 @@ extension Map where Key == String, Value == String {
 }
 
 extension StoredElementEnum {
+    //FIXME: this is shown twice
     func toElementType() -> ElementType? {
         switch self {
         case .node: return .node

--- a/GoInfoGame/GoInfoGame/samplepoint.gpx
+++ b/GoInfoGame/GoInfoGame/samplepoint.gpx
@@ -6,7 +6,7 @@
      waypoint, Xcode will simulate that specific location. If you provide multiple waypoints,
      Xcode will simulate a route visiting each waypoint.
      -->
-    <wpt lat="17.4620366048918" lon="78.380188562477">
+    <wpt lat="47.616061465392995" lon="-122.23018339129734">
         <name>Test Data</name>
         
         <!--

--- a/GoInfoGame/Podfile
+++ b/GoInfoGame/Podfile
@@ -8,7 +8,7 @@ target 'GoInfoGame' do
   # Pods for GoInfoGame
   
 #  pod 'SwiftOverpassAPI'
-  pod 'RealmSwift', '10.46.0'
+  pod 'RealmSwift'
   pod 'HTMLEntities', :git => 'https://github.com/Kitura/swift-html-entities.git'
   
   post_install do |installer|

--- a/GoInfoGame/Podfile.lock
+++ b/GoInfoGame/Podfile.lock
@@ -1,22 +1,34 @@
 PODS:
-  - Realm (10.46.0):
-    - Realm/Headers (= 10.46.0)
-  - Realm/Headers (10.46.0)
-  - RealmSwift (10.46.0):
-    - Realm (= 10.46.0)
+  - HTMLEntities (4.0.1)
+  - Realm (20.0.2):
+    - Realm/Headers (= 20.0.2)
+  - Realm/Headers (20.0.2)
+  - RealmSwift (20.0.2):
+    - Realm (= 20.0.2)
 
 DEPENDENCIES:
-  - RealmSwift (= 10.46.0)
+  - HTMLEntities (from `https://github.com/Kitura/swift-html-entities.git`)
+  - RealmSwift
 
 SPEC REPOS:
   trunk:
     - Realm
     - RealmSwift
 
-SPEC CHECKSUMS:
-  Realm: 699b80d8e5fc66acafd2d530199e77781a2d69d3
-  RealmSwift: 3230b8fc63759433a6938a0dd2a5dc0dc2b15760
+EXTERNAL SOURCES:
+  HTMLEntities:
+    :git: https://github.com/Kitura/swift-html-entities.git
 
-PODFILE CHECKSUM: 2e47eefcaf03efee0332e9ee54fb46e8551f9191
+CHECKOUT OPTIONS:
+  HTMLEntities:
+    :commit: d8ca73197f59ce260c71bd6d7f6eb8bbdccf508b
+    :git: https://github.com/Kitura/swift-html-entities.git
+
+SPEC CHECKSUMS:
+  HTMLEntities: 4baa0d4e9cffcadb10d38b8b5d758f9e65f6d166
+  Realm: 395416e3b150a37ca12fee6477a2ec8c11f8a048
+  RealmSwift: 199fd4d7e86491d1147c662c6a36aa55136a54d0
+
+PODFILE CHECKSUM: 6a317fbf84c359780e452117e3f2419b84e92b8e
 
 COCOAPODS: 1.16.2

--- a/GoInfoGame/osmapi/models/OSMNode.swift
+++ b/GoInfoGame/osmapi/models/OSMNode.swift
@@ -52,6 +52,26 @@ public struct OSMNode: Codable, OSMPayload, OSMElement, OSMCreatePayload {
          
     }
     
+    public func fetchInternalGigTags() -> [String:String] {
+        
+        var internalTags:[String:String] = [:]
+        let dateFormatter = DateFormatter()
+
+        // Set the date format to "yyyy-MM-dd"
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+
+        // Create a Date object (for example, the current date)
+        let currentDate = Date()
+
+        // Convert the Date object to a formatted string
+        let formattedDate = dateFormatter.string(from: currentDate)
+        //"ext:gig_last_updated"
+        internalTags["ext:gig_last_updated"] = formattedDate
+        internalTags["ext:gig_complete"] = "yes"
+        
+        return internalTags
+    }
+    
     ///
     public func toPayload(exclude_gig_tags: Bool = false) -> String {
          var osmNode = "<modify>"

--- a/GoInfoGame/osmapi/models/OSMWay.swift
+++ b/GoInfoGame/osmapi/models/OSMWay.swift
@@ -19,6 +19,28 @@ public struct OSMWayResponse: Codable {
 public struct OSMWay: Codable, OSMPayload, OSMElement  {
     public var isInteresting: Bool? = false
     public var isSkippable: Bool? = false
+    
+    public func fetchInternalGigTags() -> [String:String] {
+        
+        var internalTags:[String:String] = [:]
+        let dateFormatter = DateFormatter()
+
+        // Set the date format to "yyyy-MM-dd"
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+
+        // Create a Date object (for example, the current date)
+        let currentDate = Date()
+
+        // Convert the Date object to a formatted string
+        let formattedDate = dateFormatter.string(from: currentDate)
+        //"ext:gig_last_updated"
+        internalTags["ext:gig_last_updated"] = formattedDate
+        internalTags["ext:gig_complete"] = "yes"
+        
+        return internalTags
+    }
+    
+    
     public func toPayload(exclude_gig_tags: Bool = false) -> String {
         var osmNode = "<modify>"
         let xmlBuilder = OSMXMLBuilder(rootName: "way")


### PR DESCRIPTION
This pull request introduces several enhancements and fixes across the `GoInfoGame` project, focusing on database handling, UI updates, and bug fixes. The changes include improvements to the database models and connectors, addition of new methods for handling undo functionality, and updates to UI components for better user experience.

The task related to this is https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/1799

### Database Enhancements:
* Added new fields (`version`, `point`, `nodes`, etc.) to `StoredChangeset` to support more detailed data storage and undo functionality. Also added methods `asOSMWay` and `asOSMNode` for converting database objects to OSM-compatible formats.
* Simplified `addWayTags` and `addNodeTags` methods in `DatabaseConnector` by removing unnecessary editable copies and directly updating the original versions.
* Introduced new methods in `DatabaseConnector` for handling undo operations, such as `updateChangesetWithUndoResultSuccess` and `assignChangesetId` with additional parameters. [[1]](diffhunk://#diff-7220231e18056ab777a15caa536de91d49767028c5d03d0fa2c1ab29747e2c1bL404-R386) [[2]](diffhunk://#diff-7220231e18056ab777a15caa536de91d49767028c5d03d0fa2c1ab29747e2c1bL447-R411)

### UI Updates:
* Added a method `checkAndDeleteWorkspaceDB` in `InitialViewModel` to clear the database when switching workspaces, ensuring data consistency.
* Updated `MapView` to handle undo operations with a new case `.undoDone`, showing alerts and refreshing the map after undo submission.

### Bug Fixes and Code Cleanup:
* Fixed a bug in `ApiManager` to include the invalid JSON string in the error message for better debugging.
* Removed redundant `asOSMWay` and `asOSMNode` methods from `StoredNode` and `StoredWay` classes to reduce code duplication. [[1]](diffhunk://#diff-18e4843694caf7bfa30232d4c3d664ba2371b074c5e2babd2ddbc7bb319c2121L34-L47) [[2]](diffhunk://#diff-9414d99868cb907ca8e363d939ecea578d3e8a4827d56a2fa50174fb5d4313bbL62-L70)
* Replaced `tags.asKeyValueSequence()` with direct iteration over `tags` for cleaner code in multiple database model classes. [[1]](diffhunk://#diff-636ed67f84990b04ecdf84a91f915989e7a9524b68554615ed8d79489da5b415L21-R21) [[2]](diffhunk://#diff-9414d99868cb907ca8e363d939ecea578d3e8a4827d56a2fa50174fb5d4313bbL47-R47)

These changes collectively improve the functionality, maintainability, and user experience of the application.

## Internal testing done for the following

### Testing for Undo functionality
- Complete quest on a  node and way, perform undo one by one.  The elements reappear on the map (as expected)
- Complete quest on multiple nodes and ways, they show up as individual edits in the undo menu. Tried to undo every element. They appear back on the UI as expected
- Completed one quest, added some new tags using Workspaces Browser editor (Rapid Editor). Performed undo, the added tags from the quest are removed and the new tags from Rapid Editor stay in-tact as expected
- Completed one quest, changed one of the answer tags on the server using Rapid Editor. Peformed undo, the undo changes will not reflect as expected (because of the server changes)
- Closed the app and relaunched again. The Undo items are still present
- 

###  Workspace switching
- After completing few quests in a workspace, using the switch workspace option, switched to another workspace. The edits are deleted as expected
- After completing few quests, using switch workspace option, switched back to the same workspace. The edits are available as expected
- After completing few quests, logged out. Logged in again and chose the same workspace. The edits are not available as expected.


