### PR TITLE
Fixed No quests are available issue on switching the workspaces

### DIFF
--- a/GoInfoGame/GoInfoGame/UI/InitialView/InitialViewModel.swift
+++ b/GoInfoGame/GoInfoGame/UI/InitialView/InitialViewModel.swift
@@ -113,6 +113,7 @@ class InitialViewModel: ObservableObject {
                     self.saveLongQuestsToDefaults(longQuestJson: longQuestsResponse)
                     
                     // Add one generic form for each longquest
+                    QuestsRepository.shared.allQuests.removeAll()
                     for (index, quest) in self.longQuests.enumerated() {
                         let applicableQuest = ApplicableQuest(
                             quest: LongElementQuest(


### PR DESCRIPTION
By removing the quests array in the singleton class before adding the new long-form quest, this is resolved.


https://github.com/user-attachments/assets/23f2dc82-a122-46ee-98f5-ae18f5eb29bb

https://github.com/user-attachments/assets/87d47985-a9c3-4f95-bd1e-2c09f3a41460


https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/2005
