### PR TITLE
Fixed multi choice quest answer delimiter issue with ';'

### DIFF
--- a/GoInfoGame/GoInfoGame/quests/LongQuests/Components/QuestOptions.swift
+++ b/GoInfoGame/GoInfoGame/quests/LongQuests/Components/QuestOptions.swift
@@ -166,7 +166,7 @@ private extension QuestOptions {
         }
 
         private func initializeSelectedValues() {
-            let currentSelectedValues = Set((selectedChoice?.value ?? "").components(separatedBy: ", ").filter { !$0.isEmpty })
+            let currentSelectedValues = Set((selectedChoice?.value ?? "").components(separatedBy: ";").filter { !$0.isEmpty })
             if selectedValues != currentSelectedValues {
                 selectedValues = currentSelectedValues
             }
@@ -181,7 +181,7 @@ private extension QuestOptions {
         }
 
         private func updateSelectedChoice() {
-            let combinedValue = selectedValues.sorted().joined(separator: ", ")
+            let combinedValue = selectedValues.sorted().joined(separator: ";")
 
             if combinedValue.isEmpty {
                 if selectedChoice != nil {


### PR DESCRIPTION
fixed option separation from ', ' to ';'

Ticket: https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/2367

<img width="438" height="309" alt="Bug-2367" src="https://github.com/user-attachments/assets/59a3457d-29e2-4267-a1c2-0e84b011d022" />
