### PR TITLE
Bug 2750 accessible labels for buttons and other interactive elements

### DIFF
--- a/GoInfoGame/GoInfoGame/Helpers/Generated/Strings+Generated.swift
+++ b/GoInfoGame/GoInfoGame/Helpers/Generated/Strings+Generated.swift
@@ -15,6 +15,8 @@ internal enum L10n {
     internal static let accessibilityMode = L10n.tr("Localizable", "Accessibility Mode", fallback: "Accessibility Mode")
     /// AVIV ScoutRoute
     internal static let appName = L10n.tr("Localizable", "App Name", fallback: "AVIV ScoutRoute")
+    /// Back
+    internal static let back = L10n.tr("Localizable", "Back", fallback: "Back")
     /// Cancel
     internal static let cancel = L10n.tr("Localizable", "Cancel", fallback: "Cancel")
     /// Can't Say

--- a/GoInfoGame/GoInfoGame/Helpers/Generated/Strings+Generated.swift
+++ b/GoInfoGame/GoInfoGame/Helpers/Generated/Strings+Generated.swift
@@ -57,6 +57,8 @@ internal enum L10n {
     internal static let otherAnswers = L10n.tr("Localizable", "other_answers", fallback: "OTHER ANSWERS...")
     /// Preferences
     internal static let preferences = L10n.tr("Localizable", "Preferences", fallback: "Preferences")
+    /// Profile
+    internal static let profile = L10n.tr("Localizable", "Profile", fallback: "Profile")
     /// Quest Type
     internal static let questType = L10n.tr("Localizable", "Quest Type", fallback: "Quest Type")
     /// Are there one or more street lamps within 10 feet of this Bus stop?

--- a/GoInfoGame/GoInfoGame/Helpers/Generated/Strings+Generated.swift
+++ b/GoInfoGame/GoInfoGame/Helpers/Generated/Strings+Generated.swift
@@ -35,6 +35,8 @@ internal enum L10n {
     internal static let dateTime = L10n.tr("Localizable", "Date & Time", fallback: "Date & Time")
     /// Don't show again for this session
     internal static let dontShowAgain = L10n.tr("Localizable", "dont_show_again", fallback: "Don't show again for this session")
+    /// Filter Quest Types
+    internal static let filterQuestTypes = L10n.tr("Localizable", "Filter Quest Types", fallback: "Filter Quest Types")
     /// Go back to map view
     internal static let goBackToMapView = L10n.tr("Localizable", "Go back to map view", fallback: "Go back to map view")
     /// Go back to previous screen
@@ -43,6 +45,8 @@ internal enum L10n {
     internal static let hideThisQuest = L10n.tr("Localizable", "Hide this quest", fallback: "Hide this quest")
     /// Invalid credentials
     internal static let invalidCredentials = L10n.tr("Localizable", "Invalid credentials", fallback: "Invalid credentials")
+    /// Map Modes.
+    internal static let mapModes = L10n.tr("Localizable", "Map Modes.", fallback: "Map Modes.")
     /// My Profile
     internal static let myProfile = L10n.tr("Localizable", "My Profile", fallback: "My Profile")
     /// New edits will appear here when a quest is answered.

--- a/GoInfoGame/GoInfoGame/UI/InitialView/InitialView.swift
+++ b/GoInfoGame/GoInfoGame/UI/InitialView/InitialView.swift
@@ -28,7 +28,7 @@ struct InitialView: View {
                                 }
                                 .frame(width: 34, height: 34)
                                 .clipShape(Circle())
-                                .accessibilityLabel("Profile")
+                                .accessibilityLabel(L10n.Localizable.profile)
                         }
                         Spacer()
                     }

--- a/GoInfoGame/GoInfoGame/UI/InitialView/InitialView.swift
+++ b/GoInfoGame/GoInfoGame/UI/InitialView/InitialView.swift
@@ -28,6 +28,7 @@ struct InitialView: View {
                                 }
                                 .frame(width: 34, height: 34)
                                 .clipShape(Circle())
+                                .accessibilityLabel("Profile")
                         }
                         Spacer()
                     }

--- a/GoInfoGame/GoInfoGame/UI/Map/MapView.swift
+++ b/GoInfoGame/GoInfoGame/UI/Map/MapView.swift
@@ -237,6 +237,7 @@ struct MapView: View {
                                 }
                                 .frame(width: 34, height: 34)
                                 .clipShape(Circle())
+                                .accessibilityLabel("Profile")
                         }
                         
                         Rectangle()

--- a/GoInfoGame/GoInfoGame/UI/Map/MapView.swift
+++ b/GoInfoGame/GoInfoGame/UI/Map/MapView.swift
@@ -237,7 +237,7 @@ struct MapView: View {
                                 }
                                 .frame(width: 34, height: 34)
                                 .clipShape(Circle())
-                                .accessibilityLabel("Profile")
+                                .accessibilityLabel(L10n.Localizable.profile)
                         }
                         
                         Rectangle()

--- a/GoInfoGame/GoInfoGame/UI/Map/MapView.swift
+++ b/GoInfoGame/GoInfoGame/UI/Map/MapView.swift
@@ -293,7 +293,7 @@ struct MapView: View {
                                 .background(Asset.Colors.e7E3EELightPurpuleBg.swiftUIColor)
                                 .frame(width: 34, height: 34)
                                 .clipShape(Circle())
-                                .accessibilityLabel("Map Modes.")
+                                .accessibilityLabel(L10n.Localizable.mapModes)
                         }
                         
                         Button(action: {

--- a/GoInfoGame/GoInfoGame/UI/Map/MapView.swift
+++ b/GoInfoGame/GoInfoGame/UI/Map/MapView.swift
@@ -293,6 +293,7 @@ struct MapView: View {
                                 .background(Asset.Colors.e7E3EELightPurpuleBg.swiftUIColor)
                                 .frame(width: 34, height: 34)
                                 .clipShape(Circle())
+                                .accessibilityLabel("Map Modes.")
                         }
                         
                         Button(action: {

--- a/GoInfoGame/GoInfoGame/UI/Map/MapView.swift
+++ b/GoInfoGame/GoInfoGame/UI/Map/MapView.swift
@@ -98,6 +98,7 @@ struct MapView: View {
                           tappedCoordinate: $tappedCoordinate,
                           annotationCoordinate: $annotationCoordinate,
                           shadowOverlay: shadowOverlay)
+                .accessibilityHidden(true)
             .onChange(of: tappedCoordinate) { _ in
                 showMapLongPressedSheet = tappedCoordinate != nil
             }

--- a/GoInfoGame/GoInfoGame/UI/Utils/FloatingActionButtonStack.swift
+++ b/GoInfoGame/GoInfoGame/UI/Utils/FloatingActionButtonStack.swift
@@ -27,6 +27,7 @@ struct FloatingActionButtonStack: View {
                             .background(.white)
                             .clipShape(Circle())
                             .shadow(radius: 10)
+                            .accessibilityLabel("Filter Quest Types")
                           
                     }
                     .sheet(isPresented: $showBottomSheet) {

--- a/GoInfoGame/GoInfoGame/UI/Utils/FloatingActionButtonStack.swift
+++ b/GoInfoGame/GoInfoGame/UI/Utils/FloatingActionButtonStack.swift
@@ -27,7 +27,7 @@ struct FloatingActionButtonStack: View {
                             .background(.white)
                             .clipShape(Circle())
                             .shadow(radius: 10)
-                            .accessibilityLabel("Filter Quest Types")
+                            .accessibilityLabel(L10n.Localizable.filterQuestTypes)
                           
                     }
                     .sheet(isPresented: $showBottomSheet) {

--- a/GoInfoGame/GoInfoGame/UserProfile/View/UserProfileView.swift
+++ b/GoInfoGame/GoInfoGame/UserProfile/View/UserProfileView.swift
@@ -134,6 +134,7 @@ struct UserProfileView: View {
                 .frame(width: 50, height: 50)
                 .foregroundStyle(.white)
                 .clipShape(Circle())
+                .accessibilityLabel("Profile")
         }
         .frame(width: 60, height: 60)
         .background{

--- a/GoInfoGame/GoInfoGame/UserProfile/View/UserProfileView.swift
+++ b/GoInfoGame/GoInfoGame/UserProfile/View/UserProfileView.swift
@@ -134,7 +134,7 @@ struct UserProfileView: View {
                 .frame(width: 50, height: 50)
                 .foregroundStyle(.white)
                 .clipShape(Circle())
-                .accessibilityLabel("Profile")
+                .accessibilityLabel(L10n.Localizable.profile)
         }
         .frame(width: 60, height: 60)
         .background{

--- a/GoInfoGame/GoInfoGame/UserProfile/View/UserProfileView.swift
+++ b/GoInfoGame/GoInfoGame/UserProfile/View/UserProfileView.swift
@@ -89,6 +89,7 @@ struct UserProfileView: View {
                             Image(systemName: "arrow.left")
                                 .resizable()
                                 .foregroundStyle(Asset.Colors.huskyPurple.swiftUIColor)
+                                .accessibilityLabel(L10n.Localizable.back)
                         }
                     }
                     

--- a/GoInfoGame/GoInfoGame/en.lproj/Localizable.strings
+++ b/GoInfoGame/GoInfoGame/en.lproj/Localizable.strings
@@ -145,3 +145,4 @@
 "Close the dialog." = "Close the dialog.";
 "Close Accessbility Mode screen." = "Close Accessbility Mode screen.";
 "Close Undo Edits screen." = "Close Undo Edits screen.";
+"Profile" = "Profile";

--- a/GoInfoGame/GoInfoGame/en.lproj/Localizable.strings
+++ b/GoInfoGame/GoInfoGame/en.lproj/Localizable.strings
@@ -146,3 +146,4 @@
 "Close Accessbility Mode screen." = "Close Accessbility Mode screen.";
 "Close Undo Edits screen." = "Close Undo Edits screen.";
 "Profile" = "Profile";
+"Back" = "Back";

--- a/GoInfoGame/GoInfoGame/en.lproj/Localizable.strings
+++ b/GoInfoGame/GoInfoGame/en.lproj/Localizable.strings
@@ -147,3 +147,5 @@
 "Close Undo Edits screen." = "Close Undo Edits screen.";
 "Profile" = "Profile";
 "Back" = "Back";
+"Map Modes." = "Map Modes.";
+"Filter Quest Types" = "Filter Quest Types";


### PR DESCRIPTION
This pull request adds accessibility improvements across several UI components by introducing descriptive accessibility labels, and updates the localization strings to support these new labels. These changes help make the app more accessible for users relying on assistive technologies.

**Accessibility improvements:**

* Added `.accessibilityLabel(L10n.Localizable.profile)` to user profile image buttons in `InitialView`, `MapView`, and `UserProfileView` to provide descriptive labels for profile-related controls. [[1]](diffhunk://#diff-f20009de1ac9b8bdb2471ec297674b03ea37377a5f71b067b813c28c0f910ab7R31) [[2]](diffhunk://#diff-68adffed77ccb06a7a46e28b7233cbe80c51831af532d1ecd432a8fcd4bffae1R241) [[3]](diffhunk://#diff-fbf2db85c9d81d506172859b858ef6ea0061b1012ead1f77acd05d336247b67bR138)
* Added `.accessibilityLabel(L10n.Localizable.mapModes)` to the map mode switch button in `MapView` for better screen reader support.
* Added `.accessibilityLabel(L10n.Localizable.filterQuestTypes)` to the filter button in `FloatingActionButtonStack` for clearer identification.
* Added `.accessibilityLabel(L10n.Localizable.back)` to the back arrow in `UserProfileView` to clarify its purpose.
* Marked the map itself as hidden from accessibility (decorative only) with `.accessibilityHidden(true)` in `MapView`.

**Localization updates:**

* Updated `Localizable.strings` to include new keys for "Profile", "Back", "Map Modes.", and "Filter Quest Types" to support the new accessibility labels.

Ticket: https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/2750

https://github.com/user-attachments/assets/6a1575bd-ba54-48fc-8357-698e35a79a36

