### PR TITLE
Bug 2751 indicate button states of interactive elements

### DIFF
--- a/GoInfoGame/GoInfoGame/Helpers/Generated/Strings+Generated.swift
+++ b/GoInfoGame/GoInfoGame/Helpers/Generated/Strings+Generated.swift
@@ -59,6 +59,10 @@ internal enum L10n {
     internal static let notNow = L10n.tr("Localizable", "Not now", fallback: "Not now")
     /// Number of quests:
     internal static let numberOfQuests = L10n.tr("Localizable", "Number of quests:", fallback: "Number of quests:")
+    /// option selected
+    internal static let optionSelected = L10n.tr("Localizable", "option selected", fallback: "option selected")
+    /// option unselected
+    internal static let optionUnselected = L10n.tr("Localizable", "option unselected", fallback: "option unselected")
     /// OTHER ANSWERS...
     internal static let otherAnswers = L10n.tr("Localizable", "other_answers", fallback: "OTHER ANSWERS...")
     /// Preferences

--- a/GoInfoGame/GoInfoGame/en.lproj/Localizable.strings
+++ b/GoInfoGame/GoInfoGame/en.lproj/Localizable.strings
@@ -149,3 +149,5 @@
 "Back" = "Back";
 "Map Modes." = "Map Modes.";
 "Filter Quest Types" = "Filter Quest Types";
+"option selected" = "option selected";
+"option unselected" = "option unselected";

--- a/GoInfoGame/GoInfoGame/quests/LongQuests/Components/LongFormImageView.swift
+++ b/GoInfoGame/GoInfoGame/quests/LongQuests/Components/LongFormImageView.swift
@@ -64,6 +64,7 @@ struct LongFormImageView: View {
         }
         .frame(width: width, height: height)
         .clipped()
+        .accessibilityHidden(true)
         
    
     }

--- a/GoInfoGame/GoInfoGame/quests/LongQuests/Components/QuestOptions.swift
+++ b/GoInfoGame/GoInfoGame/quests/LongQuests/Components/QuestOptions.swift
@@ -89,6 +89,8 @@ private extension QuestOptions {
                                         }
                                     }
                                 )
+                                .accessibilityElement(children: .combine)
+                                .accessibilityLabel((selectedChoice?.choiceText == option.choiceText) ? "\(option.choiceText) \(L10n.Localizable.optionSelected)" :  "\(option.choiceText) \(L10n.Localizable.optionUnselected)")
                             }
                         }
 
@@ -150,6 +152,8 @@ private extension QuestOptions {
                                         }
                                     }
                                 )
+                                .accessibilityElement(children: .combine)
+                                .accessibilityLabel((selectedValues.contains(option.value)) ? "\(option.choiceText) \(L10n.Localizable.optionSelected)" :  "\(option.choiceText) \(L10n.Localizable.optionUnselected)")
                             }
                         }
                     }
@@ -371,6 +375,7 @@ private extension QuestOptions {
                     .frame(width: 100, height: 100)
                     .minimumScaleFactor(0.67) // min font size is 10
             }
+            .accessibilityHidden(true)
         }
     }
 


### PR DESCRIPTION
Ticket: https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/2751
This pull request improves accessibility for quest option components and images in the app, making it easier for users with assistive technologies to understand and interact with the UI. The main changes focus on providing descriptive accessibility labels for selectable options and hiding decorative images from accessibility tools.

Accessibility improvements for quest options:

* Added `.accessibilityElement(children: .combine)` and dynamic `.accessibilityLabel` to both single and multi-select quest options in `QuestOptions.swift`, so screen readers will announce the option text along with whether it is selected or unselected. [[1]](diffhunk://#diff-e124756a4586d7d7b808e9b05c2f4f07085aaf56f2ab2b853b54e374ac4c0c18R92-R93) [[2]](diffhunk://#diff-e124756a4586d7d7b808e9b05c2f4f07085aaf56f2ab2b853b54e374ac4c0c18R155-R156)
* Introduced new localized strings for "option selected" and "option unselected" in `Localizable.strings` to support these labels.

Accessibility improvements for images:

* Set `.accessibilityHidden(true)` on decorative images in both `LongFormImageView.swift` and `QuestOptions.swift` to prevent screen readers from announcing non-informative images. [[1]](diffhunk://#diff-560eb20ffeeed511d936bf80702cbb4448007c037b26707dfb21bf325ccd577cR67) [[2]](diffhunk://#diff-e124756a4586d7d7b808e9b05c2f4f07085aaf56f2ab2b853b54e374ac4c0c18R378)

https://github.com/user-attachments/assets/d2d4f413-d107-472d-888b-c18383a202b2

