### PR TITLE
Bug 2810 asr quest update time   change from submitter's time to workspace viewer's time

### DIFF
--- a/GoInfoGame/GoInfoGame.xcodeproj/project.pbxproj
+++ b/GoInfoGame/GoInfoGame.xcodeproj/project.pbxproj
@@ -3019,7 +3019,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.1.2;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-l\"c++\"",
@@ -3084,7 +3084,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.1.2;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-l\"c++\"",

--- a/GoInfoGame/osmapi/models/OSMNode.swift
+++ b/GoInfoGame/osmapi/models/OSMNode.swift
@@ -38,6 +38,7 @@ public struct OSMNode: Codable, OSMPayload, OSMElement, OSMCreatePayload {
 
         // Set the date format to "yyyy-MM-dd"
         dateFormatter.dateFormat = "yyyy-MM-dd"
+        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
 
         // Create a Date object (for example, the current date)
         let currentDate = Date()
@@ -59,6 +60,7 @@ public struct OSMNode: Codable, OSMPayload, OSMElement, OSMCreatePayload {
 
         // Set the date format to "yyyy-MM-dd"
         dateFormatter.dateFormat = "yyyy-MM-dd"
+        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
 
         // Create a Date object (for example, the current date)
         let currentDate = Date()
@@ -112,6 +114,7 @@ public struct OSMNode: Codable, OSMPayload, OSMElement, OSMCreatePayload {
 
         // Set the date format to "yyyy-MM-dd"
         dateFormatter.dateFormat = "yyyy-MM-dd"
+        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
 
         // Create a Date object (for example, the current date)
         let currentDate = Date()

--- a/GoInfoGame/osmapi/models/OSMWay.swift
+++ b/GoInfoGame/osmapi/models/OSMWay.swift
@@ -27,6 +27,7 @@ public struct OSMWay: Codable, OSMPayload, OSMElement  {
 
         // Set the date format to "yyyy-MM-dd"
         dateFormatter.dateFormat = "yyyy-MM-dd"
+        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
 
         // Create a Date object (for example, the current date)
         let currentDate = Date()
@@ -79,6 +80,7 @@ public struct OSMWay: Codable, OSMPayload, OSMElement  {
 
        // Set the date format to "yyyy-MM-dd"
        dateFormatter.dateFormat = "yyyy-MM-dd"
+        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
 
        // Create a Date object (for example, the current date)
        let currentDate = Date()


### PR DESCRIPTION
Ticket: https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/2810

This pull request includes a minor version bump for the app and ensures that all date formatting for OSM elements uses UTC (GMT+0) time zone. This improves consistency in date handling across the codebase.

Versioning:

* Updated `MARKETING_VERSION` from `1.1.1` to `1.1.2` in `GoInfoGame.xcodeproj/project.pbxproj` to reflect a new release version. [[1]](diffhunk://#diff-f4c4f6d7944afd5d55e70847b87dc0c493ec2a7a8e36ff593273048ae753f01dL3022-R3022) [[2]](diffhunk://#diff-f4c4f6d7944afd5d55e70847b87dc0c493ec2a7a8e36ff593273048ae753f01dL3087-R3087)

Date formatting consistency:

* Added `dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)` in three places in `OSMNode.swift` to ensure dates are formatted in UTC. [[1]](diffhunk://#diff-fa5e009b460211d086a6fd3275e42c0900bbc2ced82dc226338233879130fe03R41) [[2]](diffhunk://#diff-fa5e009b460211d086a6fd3275e42c0900bbc2ced82dc226338233879130fe03R63) [[3]](diffhunk://#diff-fa5e009b460211d086a6fd3275e42c0900bbc2ced82dc226338233879130fe03R117)
* Added `dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)` in two places in `OSMWay.swift` for the same UTC date formatting consistency. [[1]](diffhunk://#diff-b0358cfbef75864a5a496a450756ff3cc6f8a6cf82c3602867e87e20370d6560R30) [[2]](diffhunk://#diff-b0358cfbef75864a5a496a450756ff3cc6f8a6cf82c3602867e87e20370d6560R83)