### PR TITLE
Zoom leve announcement feedback

### DIFF
--- a/GoInfoGame/GoInfoGame.xcodeproj/project.pbxproj
+++ b/GoInfoGame/GoInfoGame.xcodeproj/project.pbxproj
@@ -2996,7 +2996,7 @@
 				CODE_SIGN_ENTITLEMENTS = GoInfoGame/GoInfoGame.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = G8MQVE5WWW;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -3019,7 +3019,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.2;
+				MARKETING_VERSION = 1.1.3;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-l\"c++\"",
@@ -3062,7 +3062,7 @@
 				CODE_SIGN_ENTITLEMENTS = GoInfoGame/GoInfoGame.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = G8MQVE5WWW;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -3084,7 +3084,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.2;
+				MARKETING_VERSION = 1.1.3;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-l\"c++\"",

--- a/GoInfoGame/GoInfoGame/Helpers/Extensions.swift
+++ b/GoInfoGame/GoInfoGame/Helpers/Extensions.swift
@@ -76,7 +76,11 @@ extension MKMapView {
         // The distance (in meters) visible in the current map width
         return metersPerPixel * mapWidthInPixels
     }
-
+    
+    func zoomLevelFor(longitudeDelta: Double) -> Int {
+        let zoom = log2(360 / longitudeDelta)
+        return Int(max(0, zoom))
+    }
 }
 
 extension CLLocationCoordinate2D: CustomPersistable {

--- a/GoInfoGame/GoInfoGame/UI/Map/MapView.swift
+++ b/GoInfoGame/GoInfoGame/UI/Map/MapView.swift
@@ -13,6 +13,7 @@ struct MapView: View {
     let selectedWorkspace: Workspace
     @State var trackingMode: MapUserTrackingMode = MapUserTrackingMode.follow
     @Environment(\.presentationMode) private var presentationMode
+    @Environment(\.accessibilityVoiceOverEnabled) var isVoiceOverOn
     @AppStorage("isMapFromOnboarding") var isMapFromOnboarding: Bool = false
     @StateObject var viewModel: MapViewModel
     @State private var isPresented = false
@@ -192,6 +193,9 @@ struct MapView: View {
                                     region.span.longitudeDelta *= 2.0
                                     if region.span.latitudeDelta < 170.0 && region.span.longitudeDelta < 350.0 {
                                         mapViewRef?.setRegion(region, animated: true)
+                                        if let newZoom = mapViewRef?.zoomLevelFor(longitudeDelta: region.span.longitudeDelta) {
+                                            voiceOverAnnounce(message: "Zoomed out to level \(newZoom)")
+                                        }
                                     }
                                 }
                             }
@@ -202,6 +206,9 @@ struct MapView: View {
                                     region.span.latitudeDelta *= 0.5
                                     region.span.longitudeDelta *= 0.5
                                     mapViewRef?.setRegion(region, animated: true)
+                                    if let newZoom = mapViewRef?.zoomLevelFor(longitudeDelta: region.span.longitudeDelta) {
+                                        voiceOverAnnounce(message: "Zoomed in to level \(newZoom)")
+                                    }
                                 }
                             }
                             .accessibilityLabel(L10n.Localizable.zoomInMap)
@@ -562,6 +569,19 @@ struct MapView: View {
 //            let edited = DatabaseConnector.shared.getNode(id: 43)
 //            print("ORIGINAL --->>>\(original)")
 //            print("EDITED --->>>\(edited)")
+        }
+    }
+    
+    func voiceOverAnnounce(message: String) {
+        guard isVoiceOverOn else {
+            return
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            if #available(iOS 17.0, *) {
+                AccessibilityNotification.Announcement(message).post()
+            } else {
+                UIAccessibility.post(notification: .announcement, argument: message)
+            }
         }
     }
     

--- a/GoInfoGame/GoInfoGame/UI/Map/MapView.swift
+++ b/GoInfoGame/GoInfoGame/UI/Map/MapView.swift
@@ -190,7 +190,9 @@ struct MapView: View {
                                 if var region = mapViewRef?.region {
                                     region.span.latitudeDelta *= 2.0
                                     region.span.longitudeDelta *= 2.0
-                                    mapViewRef?.setRegion(region, animated: true)
+                                    if region.span.latitudeDelta < 170.0 && region.span.longitudeDelta < 350.0 {
+                                        mapViewRef?.setRegion(region, animated: true)
+                                    }
                                 }
                             }
                             .accessibilityLabel(L10n.Localizable.zoomOutMap)


### PR DESCRIPTION
This pull request introduces improvements to the map accessibility experience and updates the app's versioning information. The main focus is on providing VoiceOver announcements for map zoom actions, making the app more accessible to visually impaired users. Additionally, the project version and marketing version numbers have been updated.

**Accessibility Improvements:**
- Added a `voiceOverAnnounce` helper function in `MapView` to announce zoom level changes via VoiceOver, supporting both iOS 17 and earlier versions.
- Integrated VoiceOver announcements into the map zoom in/out actions, so users receive feedback about the current zoom level when using accessibility features. [[1]](diffhunk://#diff-68adffed77ccb06a7a46e28b7233cbe80c51831af532d1ecd432a8fcd4bffae1R194-R199) [[2]](diffhunk://#diff-68adffed77ccb06a7a46e28b7233cbe80c51831af532d1ecd432a8fcd4bffae1R209-R211)
- Introduced the `isVoiceOverOn` environment variable to conditionally trigger announcements only when VoiceOver is enabled.

**Map Functionality Enhancements:**
- Added a `zoomLevelFor(longitudeDelta:)` method to `MKMapView` to calculate the current zoom level, used in accessibility announcements.

**Versioning Updates:**
- Updated `MARKETING_VERSION` to `1.1.3` and reset `CURRENT_PROJECT_VERSION` to `1` in the Xcode project file to reflect a new release. [[1]](diffhunk://#diff-f4c4f6d7944afd5d55e70847b87dc0c493ec2a7a8e36ff593273048ae753f01dL3022-R3022) [[2]](diffhunk://#diff-f4c4f6d7944afd5d55e70847b87dc0c493ec2a7a8e36ff593273048ae753f01dL3087-R3087) [[3]](diffhunk://#diff-f4c4f6d7944afd5d55e70847b87dc0c493ec2a7a8e36ff593273048ae753f01dL2999-R2999) [[4]](diffhunk://#diff-f4c4f6d7944afd5d55e70847b87dc0c493ec2a7a8e36ff593273048ae753f01dL3065-R3065)

https://github.com/user-attachments/assets/c2c9da50-6af7-4fc8-8b52-b56f6b541bc3

