### PR TITLE
Bug 2955 aviv scout route close and hide button usability

### DIFF
--- a/GoInfoGame/GoInfoGame.xcodeproj/project.pbxproj
+++ b/GoInfoGame/GoInfoGame.xcodeproj/project.pbxproj
@@ -3019,7 +3019,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.3;
+				MARKETING_VERSION = 1.2.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-l\"c++\"",
@@ -3084,7 +3084,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.3;
+				MARKETING_VERSION = 1.2.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-l\"c++\"",

--- a/GoInfoGame/GoInfoGame/quests/LongQuests/View/LongForm.swift
+++ b/GoInfoGame/GoInfoGame/quests/LongQuests/View/LongForm.swift
@@ -70,7 +70,7 @@ struct LongForm: View, QuestForm {
     
     var body: some View {
         ZStack {
-            VStack(alignment: .leading) {
+            VStack(alignment: .leading, spacing: 0) {
                     HStack {
                         Text(elementName ?? "")
                             .font(.custom("Lato-Bold", size: 16))
@@ -230,7 +230,7 @@ struct LongForm: View, QuestForm {
                 .frame(maxWidth: .infinity)
 
             }
-            .padding(.top, 50)
+            .padding(.top, 30)
             .onChange(of: viewModel.selectedChoices) { _ in
                 viewModel.clearAnswersForHiddenQuests()
             }

--- a/GoInfoGame/GoInfoGame/quests/LongQuests/View/LongForm.swift
+++ b/GoInfoGame/GoInfoGame/quests/LongQuests/View/LongForm.swift
@@ -9,6 +9,16 @@ import SwiftUI
 import CoreLocation
 import Combine
 
+enum LongFormActiveAlert: Identifiable {
+    case hideQuestConfirmation
+    case submissionError(message: String)
+
+    var id: String {
+        // Using a simple string representation for the ID ensures each case is unique.
+        String(describing: self)
+    }
+}
+
 struct LongForm: View, QuestForm {
     
     @ObservedObject private var viewModel = LongFormViewModel()
@@ -27,11 +37,7 @@ struct LongForm: View, QuestForm {
     
     @Environment(\.presentationMode) var presentationMode
     
-    @State private var showSubmitAlert = false
-    
     @State private var showKartaviewAlert = false
-    
-    @State private var submitAlert = ""
     
     @State private var kartaViewAlert = ""
     
@@ -57,6 +63,10 @@ struct LongForm: View, QuestForm {
     @StateObject private var noteViewModel = NotesViewModel()
 
     @State private var keyboardHeight: CGFloat = 0
+    
+    @State private var activeAlert: LongFormActiveAlert?
+    
+    @State private var submitStatusMessage: String?
     
     var body: some View {
         ZStack {
@@ -88,14 +98,13 @@ struct LongForm: View, QuestForm {
                     }
                     .padding(EdgeInsets(top: 0, leading: 14, bottom: 0, trailing: 20))
                     Spacer()
-                    Button("Hide this") {
-                        withAnimation {
-                            MapViewPublisher.shared.dismissSheet.send(.hideElement(questID ?? "0", elementName ?? ""))
-                            presentationMode.wrappedValue.dismiss()
+                    HStack {
+                        Button("Ignore this quest") {
+                            activeAlert = .hideQuestConfirmation
                         }
+                        .padding(.trailing, 20)
+                        .foregroundStyle(Asset.Colors.accentPink.swiftUIColor)
                     }
-                    .padding(.trailing, 20)
-                    .foregroundStyle(Asset.Colors.accentPink.swiftUIColor)
                 }
                 
                 if showCreateNoteMessage {
@@ -170,14 +179,14 @@ struct LongForm: View, QuestForm {
                                 }
                             }
                             VStack {
-                                if showSubmitAlert {
-                                    Text(submitAlert)
+                                if let statusMessage = submitStatusMessage {
+                                    Text(statusMessage)
                                         .font(.custom("Lato-Bold", size: 16))
                                         .foregroundColor(.red)
                                         .background(Color.white)
                                         .onAppear {
                                             DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                                                showSubmitAlert = false
+                                                submitStatusMessage = nil
                                             }
                                         }
                                 }
@@ -205,10 +214,10 @@ struct LongForm: View, QuestForm {
                                 answersToSubmit["ext:kartaview_url"] = uploadedPhotos.joined(separator: ", ")
                             }
                               action(answersToSubmit)
-                          }
+                        }
                     } else {
-                        self.showSubmitAlert = true
-                        self.submitAlert = "Please answer atleast one quest to submit"
+                        self.submitStatusMessage = "Please answer atleast one quest to submit"
+                        self.activeAlert = .submissionError(message: "Please answer atleast one quest to submit")
                     }
 
                 }) {
@@ -223,6 +232,7 @@ struct LongForm: View, QuestForm {
                 .frame(maxWidth: .infinity)
 
             }
+            .padding(.top, 50)
             .onChange(of: viewModel.selectedChoices) { _ in
                 viewModel.clearAnswersForHiddenQuests()
             }
@@ -235,10 +245,7 @@ struct LongForm: View, QuestForm {
                 CameraView(capturedImage: $capturedImage, isPresented: $isCameraPresented)
                     .applyPresentationSizingPage()
                    }
-        }
-        .alert(self.submitAlert, isPresented: $showSubmitAlert) {
-            Button("OK", role: .cancel) { }
-        }
+        
         if showKartaviewAlert {
             VStack {
                 Image(systemName: "checkmark.circle.fill")
@@ -272,6 +279,24 @@ struct LongForm: View, QuestForm {
                     .background(Color.white)
                     .cornerRadius(10)
                     .shadow(radius: 10)
+            }
+        }
+        }
+        .alert(item: $activeAlert) { alertType in
+            switch alertType {
+            case .hideQuestConfirmation:
+                return Alert(
+                    title: Text("Do you want to ignore this question?"),
+                    primaryButton: .destructive(Text("Ignore and Hide")) {
+                        withAnimation {
+                            MapViewPublisher.shared.dismissSheet.send(.hideElement(questID ?? "0", elementName ?? ""))
+                            presentationMode.wrappedValue.dismiss()
+                        }
+                    },
+                    secondaryButton: .cancel()
+                )
+            case .submissionError(let message):
+                return Alert(title: Text(message), dismissButton: .default(Text("OK")))
             }
         }
     }

--- a/GoInfoGame/GoInfoGame/quests/LongQuests/View/LongForm.swift
+++ b/GoInfoGame/GoInfoGame/quests/LongQuests/View/LongForm.swift
@@ -98,13 +98,11 @@ struct LongForm: View, QuestForm {
                     }
                     .padding(EdgeInsets(top: 0, leading: 14, bottom: 0, trailing: 20))
                     Spacer()
-                    HStack {
-                        Button("Ignore this quest") {
-                            activeAlert = .hideQuestConfirmation
-                        }
-                        .padding(.trailing, 20)
-                        .foregroundStyle(Asset.Colors.accentPink.swiftUIColor)
+                    Button("Ignore this quest") {
+                        activeAlert = .hideQuestConfirmation
                     }
+                    .padding(.trailing, 20)
+                    .foregroundStyle(Asset.Colors.accentPink.swiftUIColor)
                 }
                 
                 if showCreateNoteMessage {


### PR DESCRIPTION
Ticket: https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/2955

This pull request updates the `LongForm` quest view to improve alert handling and user feedback. The main focus is on replacing the old boolean-based alert system with a more robust, enum-driven approach, which makes the code cleaner and easier to extend. Additionally, the marketing version is bumped to 1.2.0.

**User Interface and Alert Handling Improvements:**

* Replaced multiple boolean and string-based alert states (`showSubmitAlert`, `submitAlert`) with a single `LongFormActiveAlert` enum and corresponding `@State` property (`activeAlert`), simplifying alert logic and making it easier to manage multiple alert types. [[1]](diffhunk://#diff-0ab65dfbbd7401a59ba84ca77dcb6f1e75a1359f29ac11681b75dc991084d8a0R12-R21) [[2]](diffhunk://#diff-0ab65dfbbd7401a59ba84ca77dcb6f1e75a1359f29ac11681b75dc991084d8a0R67-R73) [[3]](diffhunk://#diff-0ab65dfbbd7401a59ba84ca77dcb6f1e75a1359f29ac11681b75dc991084d8a0R283-R300)
* Updated the "Hide this" button to "Ignore this quest" and connected it to the new alert system, providing a confirmation dialog before hiding a quest.
* Submission errors now use the new alert system, displaying error messages through the enum-driven alert rather than direct string/text overlays. [[1]](diffhunk://#diff-0ab65dfbbd7401a59ba84ca77dcb6f1e75a1359f29ac11681b75dc991084d8a0L173-R187) [[2]](diffhunk://#diff-0ab65dfbbd7401a59ba84ca77dcb6f1e75a1359f29ac11681b75dc991084d8a0L210-R218) [[3]](diffhunk://#diff-0ab65dfbbd7401a59ba84ca77dcb6f1e75a1359f29ac11681b75dc991084d8a0L238-R246)

**UI Consistency and Minor Enhancements:**

* Added vertical spacing to the main `VStack` and a top padding for improved layout consistency. [[1]](diffhunk://#diff-0ab65dfbbd7401a59ba84ca77dcb6f1e75a1359f29ac11681b75dc991084d8a0R67-R73) [[2]](diffhunk://#diff-0ab65dfbbd7401a59ba84ca77dcb6f1e75a1359f29ac11681b75dc991084d8a0R233)

**Project Metadata:**

* Updated the `MARKETING_VERSION` in `project.pbxproj` from 1.1.3 to 1.2.0. [[1]](diffhunk://#diff-f4c4f6d7944afd5d55e70847b87dc0c493ec2a7a8e36ff593273048ae753f01dL3022-R3022) [[2]](diffhunk://#diff-f4c4f6d7944afd5d55e70847b87dc0c493ec2a7a8e36ff593273048ae753f01dL3087-R3087)

https://github.com/user-attachments/assets/f40323c6-1f2a-4348-aea0-c2e816cca4d1

