### PR TITLE
Fixed switch workspaces visibility UI issue in iPhone 12 mini (small screen issues)

### DIFF
--- a/GoInfoGame/GoInfoGame/UI/Map/MapView.swift
+++ b/GoInfoGame/GoInfoGame/UI/Map/MapView.swift
@@ -428,7 +428,7 @@ struct MapView: View {
                     
                 })
                     .background(Color(red: 248/255, green: 248/255, blue: 248/255))
-                    .presentationDetents([.fraction(0.36)])
+                    .presentationDetents([.fraction(0.38)])
                     .interactiveDismissDisabled()
                     .presentationDragIndicator(.hidden)
                     .applyPresentationSizingPage()


### PR DESCRIPTION
Ticket: https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/2952

This pull request makes a minor adjustment to the map view's presentation in the `MapView` SwiftUI component. The only change is a slight increase in the modal's height fraction to improve the user interface.

* Increased the presentation detent fraction in `MapView` from 0.36 to 0.38, making the modal slightly taller for better visibility.

<img width="1080" height="2340" alt="Simulator Screenshot - iPhone 12 mini - 2026-01-29 at 14 23 21" src="https://github.com/user-attachments/assets/d3d3a7c7-5595-4a2a-b085-492cddbdd87d" />
