### PR TITLE
Updated quest option which is no image at background to plan black color text option

### DIFF
--- a/GoInfoGame/GoInfoGame/quests/LongQuests/Components/QuestOptions.swift
+++ b/GoInfoGame/GoInfoGame/quests/LongQuests/Components/QuestOptions.swift
@@ -361,19 +361,15 @@ private extension QuestOptions {
 
         var body: some View {
             ZStack {
-                Image("no_image")
-                    .resizable()
-                    .scaledToFill()
+                Text(text)
+                    .foregroundStyle(Color.black)
                     .frame(width: 100, height: 100)
-                    .clipped()
-                    .overlay(
+                    .minimumScaleFactor(0.67)
+                    .bold()
+                    .overlay {
                         RoundedRectangle(cornerRadius: 8)
                             .stroke(Color.gray, lineWidth: 1)
-                    )
-
-                StrokedText(text: text)
-                    .frame(width: 100, height: 100)
-                    .minimumScaleFactor(0.67) // min font size is 10
+                    }
             }
             .accessibilityHidden(true)
         }


### PR DESCRIPTION
This pull request updates the visual appearance of the `QuestOptions` component by replacing the placeholder image with a styled text label. The text is now more prominent and visually integrated, improving clarity and accessibility.

UI update:

* Replaced the placeholder image in `QuestOptions` with a bold, scalable text label, and applied a rounded rectangle border for improved styling. Removed the use of the `StrokedText` component. (`GoInfoGame/GoInfoGame/quests/LongQuests/Components/QuestOptions.swift`)
Ticket: https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/3003

<img width="1170" height="2532" alt="Task-3003-fix" src="https://github.com/user-attachments/assets/97ac3c35-8a38-4daa-8181-d2545c8b4163" />
