### PR TITLE
Bugfix Kartaview url, map issues and Keypad

### DIFF
--- a/GoInfoGame/GoInfoGame.xcodeproj/project.pbxproj
+++ b/GoInfoGame/GoInfoGame.xcodeproj/project.pbxproj
@@ -3029,7 +3029,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.3;
+				MARKETING_VERSION = 1.2.4;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-l\"c++\"",
@@ -3094,7 +3094,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.3;
+				MARKETING_VERSION = 1.2.4;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-l\"c++\"",

--- a/GoInfoGame/GoInfoGame.xcodeproj/project.pbxproj
+++ b/GoInfoGame/GoInfoGame.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		05DBBB622B164D9A00B6F110 /* RealOPElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05DBBB612B164D9A00B6F110 /* RealOPElement.swift */; };
 		05DBBB642B17204300B6F110 /* RealmOPGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05DBBB632B17204300B6F110 /* RealmOPGeometry.swift */; };
 		05DBBB662B17209600B6F110 /* RealmOPMeta.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05DBBB652B17209600B6F110 /* RealmOPMeta.swift */; };
+		171574E02FD1CC4A00AA6603 /* PhotoLookupResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171574DF2FD1CC4A00AA6603 /* PhotoLookupResponse.swift */; };
 		188843AD2B5FA2DF0008DCF8 /* TactilePavingStepsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 188843AC2B5FA2DF0008DCF8 /* TactilePavingStepsTests.swift */; };
 		188843AF2B5FB32D0008DCF8 /* WayLitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 188843AE2B5FB32D0008DCF8 /* WayLitTests.swift */; };
 		342561966FC217124BD9CFE7 /* Pods_GoInfoGame_GoInfoGameUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D539E22EFF6636F8CBA035A /* Pods_GoInfoGame_GoInfoGameUITests.framework */; };
@@ -358,6 +359,7 @@
 		05DBBB652B17209600B6F110 /* RealmOPMeta.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmOPMeta.swift; sourceTree = "<group>"; };
 		0644279A63026564F68E19C5 /* Pods-osmapi.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-osmapi.release.xcconfig"; path = "Target Support Files/Pods-osmapi/Pods-osmapi.release.xcconfig"; sourceTree = "<group>"; };
 		066F85ADCDCE7357368131F8 /* Pods_GoInfoGameTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GoInfoGameTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		171574DF2FD1CC4A00AA6603 /* PhotoLookupResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoLookupResponse.swift; sourceTree = "<group>"; };
 		188843AC2B5FA2DF0008DCF8 /* TactilePavingStepsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TactilePavingStepsTests.swift; sourceTree = "<group>"; };
 		188843AE2B5FB32D0008DCF8 /* WayLitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WayLitTests.swift; sourceTree = "<group>"; };
 		18EC425B2B84987200DE05D7 /* TactilePavingCrosswalkForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TactilePavingCrosswalkForm.swift; sourceTree = "<group>"; };
@@ -1608,6 +1610,7 @@
 		FAD5C4E62AFCBE700040C61A = {
 			isa = PBXGroup;
 			children = (
+				171574DF2FD1CC4A00AA6603 /* PhotoLookupResponse.swift */,
 				FAD5C4F12AFCBE700040C61A /* GoInfoGame */,
 				FAD5C5082AFCBE720040C61A /* GoInfoGameTests */,
 				FAD5C5122AFCBE720040C61A /* GoInfoGameUITests */,
@@ -2507,6 +2510,7 @@
 				971902112B983EFC009B3270 /* CustomMap.swift in Sources */,
 				FA5071982D71F1B000CE9798 /* SyncLogger.swift in Sources */,
 				A48037362BBA8DDC007EE7E4 /* WorkspacesResponse.swift in Sources */,
+				171574E02FD1CC4A00AA6603 /* PhotoLookupResponse.swift in Sources */,
 				C769AB552E431EFE00FA810A /* Strings+Generated.swift in Sources */,
 				0536DD992B0BDBFE00B04C4B /* OAuthManager.swift in Sources */,
 				A4E711A62B57BBCA00C9DE08 /* QuestProtocols.swift in Sources */,

--- a/GoInfoGame/GoInfoGame/Kartaview/Model/PhotoLookupResponse.swift
+++ b/GoInfoGame/GoInfoGame/Kartaview/Model/PhotoLookupResponse.swift
@@ -1,0 +1,21 @@
+//
+//  PhotoLookupResponse.swift
+//  GoInfoGame
+//
+
+import Foundation
+
+// MARK: - PhotoLookupResponse
+struct PhotoLookupResponse: Codable {
+    let result: PhotoLookupResult?
+}
+
+// MARK: - Result
+struct PhotoLookupResult: Codable {
+    let data: [PhotoLookupData]?
+}
+
+// MARK: - Data
+struct PhotoLookupData: Codable {
+    let imageLthUrl: String?
+}

--- a/GoInfoGame/GoInfoGame/Kartaview/ViewModel/KartaviewViewModel.swift
+++ b/GoInfoGame/GoInfoGame/Kartaview/ViewModel/KartaviewViewModel.swift
@@ -116,12 +116,54 @@ class KartaviewViewModel: ObservableObject {
             case .success(let success):
                 let status = success.status.httpCode
                 if status == 200 {
-                    print("PHOTO UPLOADED ----->>>> PROCEEDING TO FINISH UPLOAD")
-                    let imagePath = "https://api.openstreetcam.org/" + "\(success.osv.photo.path)/" + "th/\(success.osv.photo.photoName)"
-                    self.finishUploading(path: imagePath,sequenceId: sequenceId, completion: completion)
+                    print("PHOTO UPLOADED ----->>>> FETCHING PHOTO URL")
+                    self.fetchPhotoLthUrl(sequenceId: sequenceId, sequenceIndex: "1") { lthUrl in
+                        guard let lthUrl = lthUrl else {
+                            print("Failed to retrieve photo URL")
+                            completion("An error occured", false)
+                            return
+                        }
+                        print("PHOTO URL FETCHED -----> PROCEEDING TO FINISH UPLOAD: \(lthUrl)")
+                        self.finishUploading(path: lthUrl, sequenceId: sequenceId, completion: completion)
+                    }
                 }
             case .failure(let failure):
                 print("FAILED")
+            }
+        }
+    }
+
+    private func fetchPhotoLthUrl(sequenceId: String, sequenceIndex: String, attempt: Int = 1, maxAttempts: Int = 4, completion: @escaping (String?) -> Void) {
+        let kartaViewAccessToken = "96aca5c4b80709fc6d9aced613b51905c0fbc37870640d7bdabede269165bde7"
+        let params: [[String: Any]] = [
+            ["key": "access_token", "value": kartaViewAccessToken],
+            ["key": "sequenceId", "value": sequenceId],
+            ["key": "sequenceIndex", "value": sequenceIndex]
+        ]
+        ApiManager.shared.performRequest(to: .fetchPhotoUrlFromKartaview(params), setupType: .kartaviewV2, modelType: PhotoLookupResponse.self) { result in
+            let lthUrl: String?
+            switch result {
+            case .success(let response):
+                lthUrl = response.result?.data?.first?.imageLthUrl
+            case .failure(let error):
+                print("Photo lookup failed (attempt \(attempt)): \(error.localizedDescription)")
+                lthUrl = nil
+            }
+
+            if let lthUrl = lthUrl {
+                completion(lthUrl)
+                return
+            }
+
+            guard attempt < maxAttempts else {
+                completion(nil)
+                return
+            }
+            // KartaView often needs a moment to index a freshly uploaded photo — back off and retry.
+            let delaySeconds = pow(2.0, Double(attempt - 1))
+            print("Photo not yet available — retrying in \(delaySeconds)s (attempt \(attempt + 1)/\(maxAttempts))")
+            DispatchQueue.main.asyncAfter(deadline: .now() + delaySeconds) {
+                self.fetchPhotoLthUrl(sequenceId: sequenceId, sequenceIndex: sequenceIndex, attempt: attempt + 1, maxAttempts: maxAttempts, completion: completion)
             }
         }
     }

--- a/GoInfoGame/GoInfoGame/Kartaview/ViewModel/KartaviewViewModel.swift
+++ b/GoInfoGame/GoInfoGame/Kartaview/ViewModel/KartaviewViewModel.swift
@@ -116,16 +116,8 @@ class KartaviewViewModel: ObservableObject {
             case .success(let success):
                 let status = success.status.httpCode
                 if status == 200 {
-                    print("PHOTO UPLOADED ----->>>> FETCHING PHOTO URL")
-                    self.fetchPhotoLthUrl(sequenceId: sequenceId, sequenceIndex: "1") { lthUrl in
-                        guard let lthUrl = lthUrl else {
-                            print("Failed to retrieve photo URL")
-                            completion("An error occured", false)
-                            return
-                        }
-                        print("PHOTO URL FETCHED -----> PROCEEDING TO FINISH UPLOAD: \(lthUrl)")
-                        self.finishUploading(path: lthUrl, sequenceId: sequenceId, completion: completion)
-                    }
+                    print("PHOTO UPLOADED ----->>>> FINISHING SEQUENCE")
+                    self.finishUploading(sequenceId: sequenceId, completion: completion)
                 }
             case .failure(let failure):
                 print("FAILED")
@@ -168,9 +160,9 @@ class KartaviewViewModel: ObservableObject {
         }
     }
     
-    func finishUploading(path: String, sequenceId: String, completion: @escaping (String, Bool) -> ()) {
+    func finishUploading(sequenceId: String, completion: @escaping (String, Bool) -> ()) {
         let kartaViewAccessToken = "96aca5c4b80709fc6d9aced613b51905c0fbc37870640d7bdabede269165bde7"
-        
+
         let formData: [[String: Any]] = [
              [
                 "key": "sequenceId",
@@ -183,14 +175,22 @@ class KartaviewViewModel: ObservableObject {
                 "type": "text"
               ],
         ]
-        
+
         ApiManager.shared.performRequest(to: .finshedUploadingToKartaview(formData), setupType: .kartaview, modelType: FinishUploadingModel.self) { result in
             switch result {
             case .success(let success):
                 let status = success.status.httpCode
                 if status == 200 {
-                  print("PHOTO UPLOADED SUCCESSFULLY")
-                    completion(path, true)
+                    print("SEQUENCE FINISHED -----> FETCHING PHOTO URL")
+                    self.fetchPhotoLthUrl(sequenceId: sequenceId, sequenceIndex: "1") { lthUrl in
+                        guard let lthUrl = lthUrl else {
+                            print("Failed to retrieve photo URL")
+                            completion("An error occured", false)
+                            return
+                        }
+                        print("PHOTO URL FETCHED: \(lthUrl)")
+                        completion(lthUrl, true)
+                    }
                 }
             case .failure(let failure):
                 print("FINISHING FAILED")

--- a/GoInfoGame/GoInfoGame/Network/APIConfiguration.swift
+++ b/GoInfoGame/GoInfoGame/Network/APIConfiguration.swift
@@ -44,4 +44,8 @@ class APIConfiguration {
     func kartaViewUrl(for endpoint: APIEndpoint) -> URL? {
         return URL(string: environment.kartaViewBaseURL + endpoint.path)
     }
+
+    func kartaViewV2Url(for endpoint: APIEndpoint) -> URL? {
+        return URL(string: environment.kartaViewV2BaseURL + endpoint.path)
+    }
 }

--- a/GoInfoGame/GoInfoGame/Network/APIEndPoint.swift
+++ b/GoInfoGame/GoInfoGame/Network/APIEndPoint.swift
@@ -118,6 +118,17 @@ struct APIEndpoint {
         return APIEndpoint(path: "/photo/", method: "POST", body: nil, headers: nil, formData: formData)
     }
     
+    static let fetchPhotoUrlFromKartaview = { (formData: [[String: Any]]) in
+        let queryItems: [URLQueryItem] = formData.compactMap { entry in
+            guard let key = entry["key"] as? String, let value = entry["value"] else { return nil }
+            return URLQueryItem(name: key, value: "\(value)")
+        }
+        var components = URLComponents()
+        components.queryItems = queryItems
+        let query = components.percentEncodedQuery.map { "?\($0)" } ?? ""
+        return APIEndpoint(path: "/photo/" + query, method: "GET", body: nil, headers: nil, formData: nil)
+    }
+    
     static let finshedUploadingToKartaview = { (formData: [[String: Any]]) in
         return APIEndpoint(path: "/sequence/finished-uploading/", method: "POST", body: nil, headers: nil, formData: formData)
     

--- a/GoInfoGame/GoInfoGame/Network/APIEnvironment.swift
+++ b/GoInfoGame/GoInfoGame/Network/APIEnvironment.swift
@@ -66,6 +66,13 @@ enum APIEnvironment: String, CaseIterable {
             return "https://api.openstreetcam.org/1.0"
         }
     }
+
+    var kartaViewV2BaseURL: String {
+        switch self {
+        case .development, .staging, .production:
+            return "https://api.openstreetcam.org/2.0"
+        }
+    }
     
     func displayString() -> String {
         switch self {

--- a/GoInfoGame/GoInfoGame/Network/ApiManager.swift
+++ b/GoInfoGame/GoInfoGame/Network/ApiManager.swift
@@ -19,6 +19,7 @@ enum SetupType {
     case osm
     case userProfile
     case kartaview
+    case kartaviewV2
 }
 
 // Singleton object that deals with APIs
@@ -59,6 +60,8 @@ class ApiManager {
             finalUrl = APIConfiguration.shared.userProfileUrl(for: endpoint)
         case .kartaview:
             finalUrl = APIConfiguration.shared.kartaViewUrl(for: endpoint)
+        case .kartaviewV2:
+            finalUrl = APIConfiguration.shared.kartaViewV2Url(for: endpoint)
         }
         debugPrint("URL prepared \(Date())")
         guard let url = finalUrl else {

--- a/GoInfoGame/GoInfoGame/UI/Map/CustomMap.swift
+++ b/GoInfoGame/GoInfoGame/UI/Map/CustomMap.swift
@@ -129,7 +129,7 @@ struct CustomMap: UIViewRepresentable {
     }
     
     // Coordinator class for managing delegate methods
-    class Coordinator: NSObject, MKMapViewDelegate {
+    class Coordinator: NSObject, MKMapViewDelegate, UIGestureRecognizerDelegate {
         var parent: CustomMap
         var isRegionSet = false // boolean flag to track if region has been set
         var contextualInfo: ((String) -> Void)?
@@ -312,7 +312,9 @@ struct CustomMap: UIViewRepresentable {
                 customizeAnnotationView(annotationView, with: annotation as! DisplayUnitAnnotation)
                 annotationView.isDraggable = false
                 annotationView.isUserInteractionEnabled = true
-                annotationView.addGestureRecognizer(CustomTouchGestureRecognizer(target: self, action: #selector(handleAnnotationTouch(_:))))
+                let touchRecognizer = CustomTouchGestureRecognizer(target: self, action: #selector(handleAnnotationTouch(_:)))
+                touchRecognizer.delegate = self
+                annotationView.addGestureRecognizer(touchRecognizer)
                 annotationView.displayPriority = .required
                 annotationView.zPriority = .max
                 return annotationView
@@ -335,7 +337,24 @@ struct CustomMap: UIViewRepresentable {
                         zoomRect = zoomRect.union(pointRect)
                     }
                 }
-                mapView.setVisibleMapRect(zoomRect, animated: true)
+
+                // When members are tightly packed, the union rect is essentially a point —
+                // setVisibleMapRect won't zoom in enough for clustering to break apart.
+                // Force a deep camera zoom centered on the cluster so the pins separate.
+                let region = MKCoordinateRegion(zoomRect)
+                let tightThreshold = 0.0005 // ~55m at the equator
+                if region.span.latitudeDelta < tightThreshold && region.span.longitudeDelta < tightThreshold {
+                    let camera = MKMapCamera(
+                        lookingAtCenter: cluster.coordinate,
+                        fromDistance: 150,
+                        pitch: 0,
+                        heading: mapView.camera.heading
+                    )
+                    mapView.setCamera(camera, animated: true)
+                } else {
+                    let padding = UIEdgeInsets(top: 60, left: 60, bottom: 60, right: 60)
+                    mapView.setVisibleMapRect(zoomRect, edgePadding: padding, animated: true)
+                }
             }
         }
         
@@ -482,6 +501,12 @@ struct CustomMap: UIViewRepresentable {
             UIAccessibility.post(notification: .layoutChanged, argument: mapView)
         }
         
+        // Let the map's pan/zoom gestures run at the same time as our annotation touch recognizer,
+        // so a touch that starts on a pin can still pan the map.
+        func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+            return true
+        }
+
         @objc func handleAnnotationTouch(_ gesture: CustomTouchGestureRecognizer) {
             guard let annotation = gesture.annotation else { return }
 
@@ -500,7 +525,7 @@ struct CustomMap: UIViewRepresentable {
                         self?.currentAnnotation = nil
                     }
                 }
-            case .ended, .cancelled:
+            case .ended:
                 if let startTime = touchStartTime, let currentAnnotation = currentAnnotation {
                     let touchDuration = Date().timeIntervalSince(startTime)
                     if touchDuration < 0.5 {
@@ -508,6 +533,12 @@ struct CustomMap: UIViewRepresentable {
                         self.handleSelected(annotation: annotation)
                     }
                 }
+                touchStartTime = nil
+                currentAnnotation = nil
+                longPressTimer?.invalidate()
+                longPressTimer = nil
+            case .cancelled:
+                // Finger moved beyond the tap threshold — treat as a pan, not a tap.
                 touchStartTime = nil
                 currentAnnotation = nil
                 longPressTimer?.invalidate()
@@ -684,20 +715,35 @@ class CustomAnnotationView: MKAnnotationView {
 
 class CustomTouchGestureRecognizer: UIGestureRecognizer {
     weak var annotation: DisplayUnitAnnotation?
+    private var initialLocation: CGPoint?
+    // How far the finger can drift before we treat the touch as a pan instead of a tap.
+    private let movementTolerance: CGFloat = 10
 
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent) {
         state = .began
         if let view = view as? CustomAnnotationView, let annotation = view.annotation as? DisplayUnitAnnotation {
             self.annotation = annotation
         }
+        initialLocation = touches.first?.location(in: view)
+    }
+
+    override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent) {
+        guard let initial = initialLocation, let current = touches.first?.location(in: view) else { return }
+        let dx = current.x - initial.x
+        let dy = current.y - initial.y
+        if dx * dx + dy * dy > movementTolerance * movementTolerance {
+            state = .cancelled
+        }
     }
 
     override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent) {
         state = .ended
+        initialLocation = nil
     }
 
     override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent) {
         state = .cancelled
+        initialLocation = nil
     }
 }
 

--- a/GoInfoGame/GoInfoGame/quests/LongQuests/Components/QuestOptions.swift
+++ b/GoInfoGame/GoInfoGame/quests/LongQuests/Components/QuestOptions.swift
@@ -28,7 +28,8 @@ struct QuestOptions: View {
         case .multipleChoice:
             MultipleChoiceView(
                 options: options,
-                selectedChoice: $selectedChoice
+                selectedChoice: $selectedChoice,
+                uploadPhoto: uploadPhoto
             )
             
         case .numeric:
@@ -109,6 +110,7 @@ private extension QuestOptions {
     struct MultipleChoiceView: View {
         let options: [QuestAnswerChoice]
         @Binding var selectedChoice: QuestAnswerChoice?
+        var uploadPhoto: (Bool) -> ()
 
         @State private var selectedValues: Set<String> = []
         @State private var selectedImageURL: String? = nil
@@ -156,6 +158,12 @@ private extension QuestOptions {
                                 .accessibilityLabel((selectedValues.contains(option.value)) ? "\(option.choiceText) \(L10n.Localizable.optionSelected)" :  "\(option.choiceText) \(L10n.Localizable.optionUnselected)")
                             }
                         }
+
+                        FollowUpButton(
+                            options: options,
+                            selectedChoice: $selectedChoice,
+                            uploadPhoto: uploadPhoto
+                        )
                     }
                     .padding()
                 }
@@ -397,8 +405,14 @@ private extension QuestOptions {
         @Binding var selectedChoice: QuestAnswerChoice?
         let uploadPhoto: (Bool) -> Void
 
+        private var followUpText: String? {
+            guard let value = selectedChoice?.value else { return nil }
+            let selectedValues = Set(value.components(separatedBy: ";").filter { !$0.isEmpty })
+            return options.first(where: { selectedValues.contains($0.value) && $0.choiceFollowUp != nil })?.choiceFollowUp
+        }
+
         var body: some View {
-            if let selected = selectedChoice, selected.choiceFollowUp != nil {
+            if let followUp = followUpText {
                 Button(action: {
                     uploadPhoto(true)
                 }) {
@@ -407,7 +421,7 @@ private extension QuestOptions {
                             .font(.system(size: 14, weight: .medium))
                             .foregroundColor(.white)
 
-                        Text(selected.choiceFollowUp ?? "Upload a picture")
+                        Text(followUp)
                             .font(.custom("Lato-Regular", size: 13))
                             .foregroundColor(.white)
                             .multilineTextAlignment(.leading)

--- a/GoInfoGame/GoInfoGame/quests/LongQuests/Components/QuestOptions.swift
+++ b/GoInfoGame/GoInfoGame/quests/LongQuests/Components/QuestOptions.swift
@@ -228,7 +228,7 @@ private extension QuestOptions {
                 ))
                 .font(FontFamily.Lato.regular.swiftUIFont(size: 14, relativeTo: .body))
                 .textFieldStyle(PlainTextFieldStyle())
-                .keyboardType(.numberPad)
+                .keyboardType(.decimalPad)
                 .padding(.vertical, 12) // Adds internal space
                 .padding(.horizontal, 10)
                 .frame(minWidth: 100, minHeight: 44) // Meets accessibility minimums

--- a/GoInfoGame/PhotoLookupResponse.swift
+++ b/GoInfoGame/PhotoLookupResponse.swift
@@ -1,0 +1,21 @@
+//
+//  PhotoLookupResponse.swift
+//  GoInfoGame
+//
+
+import Foundation
+
+// MARK: - PhotoLookupResponse
+struct PhotoLookupResponse: Codable {
+    let result: PhotoLookupResult?
+}
+
+// MARK: - Result
+struct PhotoLookupResult: Codable {
+    let data: [PhotoLookupData]?
+}
+
+// MARK: - Data
+struct PhotoLookupData: Codable {
+    let imageLthUrl: String?
+}


### PR DESCRIPTION
This pull request introduces several improvements and new features across the codebase, focusing on enhancing the photo upload workflow, improving map annotation interactions, and refining the quest options UI. The most significant changes are the introduction of a robust photo URL retrieval mechanism after upload, improved gesture handling for map annotations, and UI/UX refinements for quest options.

**Photo Upload Workflow Enhancements:**

* Added a new `PhotoLookupResponse` model and integrated a retrying mechanism (`fetchPhotoLthUrl`) in `KartaviewViewModel` to reliably retrieve the photo's LTH URL after upload, using a new `/photo/` GET endpoint with exponential backoff. This ensures the app waits for the photo to be indexed before proceeding. [[1]](diffhunk://#diff-9d500371a1d255acea9d081c149d9615bfb25b68443e66d6d3c9f16cecf3b7d2R1-R21) [[2]](diffhunk://#diff-fcfbcce90c057b2ced55e9a37ebb8b1532837b32fec9e24a03683f0929dfa1ccL119-R170)
* Updated API infrastructure to support the new Kartaview v2 endpoint, including new base URL handling, endpoint definitions, and setup types. [[1]](diffhunk://#diff-dddb3ef27e91b00d3df2640a8eedf1930b61b0411a04fb5213cb54c87623eecbR47-R50) [[2]](diffhunk://#diff-a4468a516cfcf749a5499a853aaca55670082d06c99bec58712b98d09c707867R121-R131) [[3]](diffhunk://#diff-dca32992ca08f6bd4c318057e2c52be8f24df47d774e427f1bf5d1e896a9324cR70-R76) [[4]](diffhunk://#diff-107f9a3943d67010794f5c23915ff3f43176ebb0475d9df9f94be539d1c87fefR22) [[5]](diffhunk://#diff-107f9a3943d67010794f5c23915ff3f43176ebb0475d9df9f94be539d1c87fefR63-R64)
* Registered `PhotoLookupResponse.swift` in the Xcode project for build and source management. [[1]](diffhunk://#diff-f4c4f6d7944afd5d55e70847b87dc0c493ec2a7a8e36ff593273048ae753f01dR24) [[2]](diffhunk://#diff-f4c4f6d7944afd5d55e70847b87dc0c493ec2a7a8e36ff593273048ae753f01dR362) [[3]](diffhunk://#diff-f4c4f6d7944afd5d55e70847b87dc0c493ec2a7a8e36ff593273048ae753f01dR1613) [[4]](diffhunk://#diff-f4c4f6d7944afd5d55e70847b87dc0c493ec2a7a8e36ff593273048ae753f01dR2513)

**Map Annotation and Gesture Improvements:**

* Enhanced the `CustomMap` annotation gesture recognizer to distinguish between taps and pans by tracking finger movement, canceling the tap if the finger drifts too far, and allowing simultaneous recognition with map pan/zoom gestures for better user experience. [[1]](diffhunk://#diff-71eafae6edfd08129b15ccfe2f638162546d5deb345c5e732e98e2e25795da48L132-R132) [[2]](diffhunk://#diff-71eafae6edfd08129b15ccfe2f638162546d5deb345c5e732e98e2e25795da48L315-R317) [[3]](diffhunk://#diff-71eafae6edfd08129b15ccfe2f638162546d5deb345c5e732e98e2e25795da48R504-R509) [[4]](diffhunk://#diff-71eafae6edfd08129b15ccfe2f638162546d5deb345c5e732e98e2e25795da48L503-R528) [[5]](diffhunk://#diff-71eafae6edfd08129b15ccfe2f638162546d5deb345c5e732e98e2e25795da48R540-R545) [[6]](diffhunk://#diff-71eafae6edfd08129b15ccfe2f638162546d5deb345c5e732e98e2e25795da48R718-R746)
* Improved cluster zooming behavior: when annotations are tightly packed, the map now zooms in more deeply to break apart clusters, ensuring pins are accessible even in dense areas.

**Quest Options UI/UX Refinements:**

* Updated the multiple choice quest component to always render the follow-up photo upload button when any selected option requires a follow-up, not just the first selected. [[1]](diffhunk://#diff-e124756a4586d7d7b808e9b05c2f4f07085aaf56f2ab2b853b54e374ac4c0c18L31-R32) [[2]](diffhunk://#diff-e124756a4586d7d7b808e9b05c2f4f07085aaf56f2ab2b853b54e374ac4c0c18R113) [[3]](diffhunk://#diff-e124756a4586d7d7b808e9b05c2f4f07085aaf56f2ab2b853b54e374ac4c0c18R161-R166) [[4]](diffhunk://#diff-e124756a4586d7d7b808e9b05c2f4f07085aaf56f2ab2b853b54e374ac4c0c18R408-R415)
* Changed the keyboard type for numeric quest options to `.decimalPad` to allow decimal input, improving accessibility and input accuracy.