### PR TITLE
Task 3921 add photo support to long press notes

### DIFF
--- a/GoInfoGame/GoInfoGame.xcodeproj/project.pbxproj
+++ b/GoInfoGame/GoInfoGame.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		A48037332BBA8D00007EE7E4 /* WorkspacesApiManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A48037322BBA8D00007EE7E4 /* WorkspacesApiManagerTests.swift */; };
 		A48037362BBA8DDC007EE7E4 /* WorkspacesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = A48037352BBA8DDC007EE7E4 /* WorkspacesResponse.swift */; };
 		A4834A3F2B67737500D4F0AA /* StoredChangeset.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4834A3E2B67737500D4F0AA /* StoredChangeset.swift */; };
+		94364F3654B754DC7499335C /* StoredNoteDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16DDF6D11556A5A5F2F1C860 /* StoredNoteDraft.swift */; };
 		A4834A412B67885E00D4F0AA /* DatasyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4834A402B67885E00D4F0AA /* DatasyncManager.swift */; };
 		A4834A442B679CE000D4F0AA /* DatasyncManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4834A432B679CE000D4F0AA /* DatasyncManagerTests.swift */; };
 		A495DF2B2B68D6EC00478E44 /* TestQuestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A495DF2A2B68D6EC00478E44 /* TestQuestUtils.swift */; };
@@ -258,6 +259,7 @@
 		FAF44FBF2B3084FB004FE664 /* OnboardingView2.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAF44FBE2B3084FB004FE664 /* OnboardingView2.swift */; };
 		FAF44FC12B30850A004FE664 /* OnboardingView3.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAF44FC02B30850A004FE664 /* OnboardingView3.swift */; };
 		FAFDA1FA2C6B861A00ECEAE9 /* FileStorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAFDA1F92C6B861A00ECEAE9 /* FileStorageManager.swift */; };
+		70CFF415C62865D5A2F409AD /* NoteImageStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86C5ED636FC6D3C98650F231 /* NoteImageStorage.swift */; };
 		FAFDA1FF2C6D337800ECEAE9 /* PosmLoginModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAFDA1FE2C6D337800ECEAE9 /* PosmLoginModel.swift */; };
 		FAFDA2022C6D33C300ECEAE9 /* PosmLoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAFDA2012C6D33C300ECEAE9 /* PosmLoginViewModel.swift */; };
 		FAFDA2042C6E8BEA00ECEAE9 /* APIEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAFDA2032C6E8BEA00ECEAE9 /* APIEnvironment.swift */; };
@@ -455,6 +457,7 @@
 		A48037322BBA8D00007EE7E4 /* WorkspacesApiManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspacesApiManagerTests.swift; sourceTree = "<group>"; };
 		A48037352BBA8DDC007EE7E4 /* WorkspacesResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspacesResponse.swift; sourceTree = "<group>"; };
 		A4834A3E2B67737500D4F0AA /* StoredChangeset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoredChangeset.swift; sourceTree = "<group>"; };
+		16DDF6D11556A5A5F2F1C860 /* StoredNoteDraft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoredNoteDraft.swift; sourceTree = "<group>"; };
 		A4834A402B67885E00D4F0AA /* DatasyncManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatasyncManager.swift; sourceTree = "<group>"; };
 		A4834A432B679CE000D4F0AA /* DatasyncManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatasyncManagerTests.swift; sourceTree = "<group>"; };
 		A495DF2A2B68D6EC00478E44 /* TestQuestUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestQuestUtils.swift; sourceTree = "<group>"; };
@@ -640,6 +643,7 @@
 		FAF44FBE2B3084FB004FE664 /* OnboardingView2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView2.swift; sourceTree = "<group>"; };
 		FAF44FC02B30850A004FE664 /* OnboardingView3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView3.swift; sourceTree = "<group>"; };
 		FAFDA1F92C6B861A00ECEAE9 /* FileStorageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileStorageManager.swift; sourceTree = "<group>"; };
+		86C5ED636FC6D3C98650F231 /* NoteImageStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteImageStorage.swift; sourceTree = "<group>"; };
 		FAFDA1FE2C6D337800ECEAE9 /* PosmLoginModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PosmLoginModel.swift; sourceTree = "<group>"; };
 		FAFDA2012C6D33C300ECEAE9 /* PosmLoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PosmLoginViewModel.swift; sourceTree = "<group>"; };
 		FAFDA2032C6E8BEA00ECEAE9 /* APIEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIEnvironment.swift; sourceTree = "<group>"; };
@@ -832,6 +836,7 @@
 				A4B83AF02B5F92FA006684CA /* StoredNode.swift */,
 				A4B83AF22B5F9385006684CA /* StoredWay.swift */,
 				A4834A3E2B67737500D4F0AA /* StoredChangeset.swift */,
+				16DDF6D11556A5A5F2F1C860 /* StoredNoteDraft.swift */,
 			);
 			path = DBModels;
 			sourceTree = "<group>";
@@ -1663,6 +1668,7 @@
 				C787F3412E9CD34900BEF0A6 /* ForceUpdateManager.swift */,
 				C7D3103D2EA0B3BB00CA10A9 /* ForceUpdateViewModifier.swift */,
 				FAFDA1F92C6B861A00ECEAE9 /* FileStorageManager.swift */,
+				86C5ED636FC6D3C98650F231 /* NoteImageStorage.swift */,
 				05CB71DD2B0FAEC200DED821 /* UI */,
 				05CB71DE2B0FAFAA00DED821 /* Bridges */,
 				058EADD92B10E02E0017E259 /* DataBase */,
@@ -2413,8 +2419,10 @@
 				C78E8BC42EDF2D55002215C0 /* EditedTagView.swift in Sources */,
 				FA18CAE72CC80A34008247F2 /* UploadPhotoModel.swift in Sources */,
 				FAFDA1FA2C6B861A00ECEAE9 /* FileStorageManager.swift in Sources */,
+				70CFF415C62865D5A2F409AD /* NoteImageStorage.swift in Sources */,
 				FAEE21DB2DCA1963002F9BEC /* UndoButton.swift in Sources */,
 				A4834A3F2B67737500D4F0AA /* StoredChangeset.swift in Sources */,
+				94364F3654B754DC7499335C /* StoredNoteDraft.swift in Sources */,
 				FAFDA2082C6E8F2500ECEAE9 /* APIConfiguration.swift in Sources */,
 				971342752BBD254200174EBF /* InitialViewModel.swift in Sources */,
 				FA5071902D5B31CC00CE9798 /* CreateNoteView.swift in Sources */,

--- a/GoInfoGame/GoInfoGame.xcodeproj/project.pbxproj
+++ b/GoInfoGame/GoInfoGame.xcodeproj/project.pbxproj
@@ -142,6 +142,7 @@
 		A4E711A82B57CA4300C9DE08 /* QuestsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4E711A72B57CA4300C9DE08 /* QuestsRepository.swift */; };
 		B0CCB98C2B8626AE00AA73DE /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0CCB98B2B8626AE00AA73DE /* ProfileView.swift */; };
 		B0CCB98E2B8626C600AA73DE /* ProfileViewVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0CCB98D2B8626C600AA73DE /* ProfileViewVM.swift */; };
+		C714D9542FFFCBB500CA1CB4 /* NotesSubmissionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C714D9532FFFCBB500CA1CB4 /* NotesSubmissionManager.swift */; };
 		C71EB5AC2E2100510009E610 /* WMTSServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71EB5AA2E2100510009E610 /* WMTSServer.swift */; };
 		C71EB5AD2E2100510009E610 /* SatellitePickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71EB5A82E2100510009E610 /* SatellitePickerSheet.swift */; };
 		C71EB5AE2E2100510009E610 /* SatelliteServerResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71EB5A92E2100510009E610 /* SatelliteServerResponse.swift */; };
@@ -522,6 +523,7 @@
 		B0CCB98B2B8626AE00AA73DE /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
 		B0CCB98D2B8626C600AA73DE /* ProfileViewVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewVM.swift; sourceTree = "<group>"; };
 		C4F37DA661B22FA87DF8282F /* Pods_osmapi.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_osmapi.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C714D9532FFFCBB500CA1CB4 /* NotesSubmissionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesSubmissionManager.swift; sourceTree = "<group>"; };
 		C71EB5A82E2100510009E610 /* SatellitePickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SatellitePickerSheet.swift; sourceTree = "<group>"; };
 		C71EB5A92E2100510009E610 /* SatelliteServerResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SatelliteServerResponse.swift; sourceTree = "<group>"; };
 		C71EB5AA2E2100510009E610 /* WMTSServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WMTSServer.swift; sourceTree = "<group>"; };
@@ -898,6 +900,7 @@
 		971575152B5FFD5F0044797C /* Map */ = {
 			isa = PBXGroup;
 			children = (
+				C714D9532FFFCBB500CA1CB4 /* NotesSubmissionManager.swift */,
 				C79C3B782ED4557400F80364 /* Accessibility Mode */,
 				C71EB5AF2E2100B80009E610 /* MapRepository.swift */,
 				C71EB5AB2E2100510009E610 /* Satellite Server */,
@@ -2480,6 +2483,7 @@
 				C75EAD362E042D4500F75969 /* SideWalkWidth.swift in Sources */,
 				C7E9528D2ED887CC001BFB75 /* NoQuestsNearView.swift in Sources */,
 				C75EAD372E042D4500F75969 /* SideWalkWidthForm.swift in Sources */,
+				C714D9542FFFCBB500CA1CB4 /* NotesSubmissionManager.swift in Sources */,
 				C76B63792E4605570076A540 /* Fonts+Generated.swift in Sources */,
 				FA1992ED2BB1A78C003B4719 /* KeychainManager.swift in Sources */,
 				C78E8BC22EDF20E6002215C0 /* UndoItemConfirmationView.swift in Sources */,

--- a/GoInfoGame/GoInfoGame/DataBase/DBModels/StoredNoteDraft.swift
+++ b/GoInfoGame/GoInfoGame/DataBase/DBModels/StoredNoteDraft.swift
@@ -1,0 +1,34 @@
+//
+//  StoredNoteDraft.swift
+//  GoInfoGame
+//
+
+import Foundation
+import RealmSwift
+import CoreLocation
+
+/// A note (with any captured photos already saved to disk) still waiting to be
+/// uploaded to Kartaview and submitted to the notes API. Presence of a row here
+/// means the note is pending — the row is deleted once submission succeeds, which
+/// is what lets a note captured offline (or interrupted mid-upload) survive an app
+/// kill and be retried later from the sync button or on next app launch.
+class StoredNoteDraft: Object {
+    @Persisted(primaryKey: true) var id: String = UUID().uuidString
+    @Persisted var noteText: String = ""
+    @Persisted var imagePaths: List<String> = List<String>()
+    @Persisted var latitude: Double = 0.0
+    @Persisted var longitude: Double = 0.0
+    @Persisted var createdAt: Date = Date()
+    @Persisted var lastError: String?
+    @Persisted var retryCount: Int = 0
+}
+
+/// Plain-value mirror of a StoredNoteDraft. Realm objects are confined to the thread/
+/// Realm instance that fetched them, so this is what crosses into async Task and actor
+/// contexts while a queued note is being retried.
+struct StoredNoteDraftSnapshot {
+    let id: String
+    let noteText: String
+    let imagePaths: [String]
+    let coordinates: CLLocationCoordinate2D
+}

--- a/GoInfoGame/GoInfoGame/DataBase/DatabaseConnector.swift
+++ b/GoInfoGame/GoInfoGame/DataBase/DatabaseConnector.swift
@@ -452,6 +452,69 @@ class DatabaseConnector {
         return theWay
     }
 
+    // MARK: - Note drafts (offline queue for Create Note)
+
+    /// Creates the pending note draft, or if `id` already exists (a retry of a
+    /// previously failed draft), overwrites its text/photos/coordinates in place.
+    @discardableResult
+    func upsertNoteDraft(id: String, noteText: String, imagePaths: [String], coordinates: CLLocationCoordinate2D) -> StoredNoteDraft {
+        let realm = try! Realm(configuration: RealmConfig.configuration)
+        let draft = StoredNoteDraft()
+        draft.id = id
+        draft.noteText = noteText
+        draft.imagePaths.append(objectsIn: imagePaths)
+        draft.latitude = coordinates.latitude
+        draft.longitude = coordinates.longitude
+        draft.createdAt = Date()
+        try! realm.write {
+            realm.add(draft, update: .modified)
+        }
+        return draft
+    }
+
+    /// All notes still waiting to be uploaded/submitted, oldest first.
+    func pendingNoteDrafts() -> [StoredNoteDraftSnapshot] {
+        let realm = try! Realm(configuration: RealmConfig.configuration)
+        return realm.objects(StoredNoteDraft.self)
+            .sorted(byKeyPath: "createdAt")
+            .map {
+                StoredNoteDraftSnapshot(
+                    id: $0.id,
+                    noteText: $0.noteText,
+                    imagePaths: Array($0.imagePaths),
+                    coordinates: CLLocationCoordinate2D(latitude: $0.latitude, longitude: $0.longitude)
+                )
+            }
+    }
+
+    func pendingNoteDraftsCount() -> Int {
+        let realm = try! Realm(configuration: RealmConfig.configuration)
+        return realm.objects(StoredNoteDraft.self).count
+    }
+
+    func noteDraftImagePaths(id: String) -> [String] {
+        let realm = try! Realm(configuration: RealmConfig.configuration)
+        guard let draft = realm.object(ofType: StoredNoteDraft.self, forPrimaryKey: id) else { return [] }
+        return Array(draft.imagePaths)
+    }
+
+    func deleteNoteDraft(id: String) {
+        let realm = try! Realm(configuration: RealmConfig.configuration)
+        guard let draft = realm.object(ofType: StoredNoteDraft.self, forPrimaryKey: id) else { return }
+        try! realm.write {
+            realm.delete(draft)
+        }
+    }
+
+    func markNoteDraftFailed(id: String, error: String) {
+        let realm = try! Realm(configuration: RealmConfig.configuration)
+        guard let draft = realm.object(ofType: StoredNoteDraft.self, forPrimaryKey: id) else { return }
+        try! realm.write {
+            draft.lastError = error
+            draft.retryCount += 1
+        }
+    }
+
 }
 
 struct RealmConfig {

--- a/GoInfoGame/GoInfoGame/Kartaview/ViewModel/KartaviewViewModel.swift
+++ b/GoInfoGame/GoInfoGame/Kartaview/ViewModel/KartaviewViewModel.swift
@@ -58,16 +58,20 @@ class KartaviewViewModel: ObservableObject {
                     print("SEQUENCE CREATED ------> PROCEEDING TO UPLOAD PHOTO")
                     // Step 2: Upload Photo after receiving sequenceId
                     self.uploadPhoto(sequenceId: self.sequenceId!, completion: completion)
+                } else {
+                    completion("Failed to create Kartaview sequence", false)
                 }
             case .failure(let error):
                 print("Failed to create sequence: \(error.localizedDescription)")
+                completion(error.localizedDescription, false)
             }
         }
     }
-    
+
     func uploadPhoto(sequenceId: String, completion: @escaping (String, Bool) -> ()) {
         guard let imageData = imageToData(image: capturedImage) else {
             print("NO image found")
+            completion("Failed to process the captured photo", false)
             return
         }
         
@@ -118,9 +122,12 @@ class KartaviewViewModel: ObservableObject {
                 if status == 200 {
                     print("PHOTO UPLOADED ----->>>> FINISHING SEQUENCE")
                     self.finishUploading(sequenceId: sequenceId, completion: completion)
+                } else {
+                    completion("Failed to upload photo to Kartaview", false)
                 }
             case .failure(let failure):
                 print("FAILED")
+                completion(failure.localizedDescription, false)
             }
         }
     }
@@ -189,6 +196,8 @@ class KartaviewViewModel: ObservableObject {
                         print("PHOTO URL FETCHED: \(lthUrl)")
                         completion(lthUrl, true)
                     }
+                } else {
+                    completion("Failed to finish Kartaview upload", false)
                 }
             case .failure(let failure):
                 print("FINISHING FAILED")
@@ -197,8 +206,21 @@ class KartaviewViewModel: ObservableObject {
         }
     }
 
-    
+
     func imageToData(image: UIImage) -> Data? {
         return image.jpegData(compressionQuality: 1.0)
+    }
+
+    /// Runs the full create-sequence → upload-photo → finish → fetch-url chain and returns the hosted photo URL.
+    func uploadAsync() async throws -> String {
+        try await withCheckedThrowingContinuation { continuation in
+            createSequence { result, success in
+                if success {
+                    continuation.resume(returning: result)
+                } else {
+                    continuation.resume(throwing: NSError(domain: "KartaviewUpload", code: 0, userInfo: [NSLocalizedDescriptionKey: result]))
+                }
+            }
+        }
     }
 }

--- a/GoInfoGame/GoInfoGame/Network/ApiManager.swift
+++ b/GoInfoGame/GoInfoGame/Network/ApiManager.swift
@@ -70,7 +70,12 @@ class ApiManager {
             return
         }
         
-        var request = URLRequest(url: url, timeoutInterval: Double.infinity)
+        // A per-request timeout (rather than none) means a hung connection eventually
+        // surfaces as a failure instead of leaving callers (e.g. MapViewModel.isLoading,
+        // NotesQueueProcessor.isProcessing) stuck waiting on a completion that never fires.
+        // Multipart uploads (photos) get a longer allowance than plain JSON calls.
+        let requestTimeout: TimeInterval = endpoint.formData != nil ? .infinity : 60
+        var request = URLRequest(url: url, timeoutInterval: requestTimeout)
         request.httpMethod = endpoint.method
         debugPrint("URLRequest prepared \(Date())")
         if let formData = endpoint.formData {

--- a/GoInfoGame/GoInfoGame/NoteImageStorage.swift
+++ b/GoInfoGame/GoInfoGame/NoteImageStorage.swift
@@ -1,0 +1,43 @@
+//
+//  NoteImageStorage.swift
+//  GoInfoGame
+//
+
+import Foundation
+import UIKit
+
+/// Persists captured note photos to disk so they survive an app kill while a note is
+/// still queued for upload. Realm isn't suited to storing image blobs, so only the
+/// file path is kept in StoredNoteDraft.
+final class NoteImageStorage {
+    static let shared = NoteImageStorage()
+
+    private let fileManager = FileManager.default
+    private let directoryURL: URL
+
+    private init() {
+        let documents = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        directoryURL = documents.appendingPathComponent("NoteImages", isDirectory: true)
+        try? fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+    }
+
+    @discardableResult
+    func save(_ image: UIImage) throws -> String {
+        guard let data = image.jpegData(compressionQuality: 0.9) else {
+            throw NSError(domain: "NoteImageStorage", code: 0, userInfo: [NSLocalizedDescriptionKey: "Failed to encode photo"])
+        }
+        let fileURL = directoryURL.appendingPathComponent("\(UUID().uuidString).jpg")
+        try data.write(to: fileURL, options: .atomic)
+        return fileURL.path
+    }
+
+    func load(path: String) -> UIImage? {
+        UIImage(contentsOfFile: path)
+    }
+
+    func delete(paths: [String]) {
+        for path in paths {
+            try? fileManager.removeItem(atPath: path)
+        }
+    }
+}

--- a/GoInfoGame/GoInfoGame/SceneDelegate.swift
+++ b/GoInfoGame/GoInfoGame/SceneDelegate.swift
@@ -61,6 +61,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         Task {
             try? await self.forceUpdateManager.checkForceUpdate()
         }
+        NotesSubmissionManager.resumePendingUploads()
     }
 
     func sceneWillResignActive(_ scene: UIScene) {

--- a/GoInfoGame/GoInfoGame/UI/Map/CreateNoteView.swift
+++ b/GoInfoGame/GoInfoGame/UI/Map/CreateNoteView.swift
@@ -13,7 +13,6 @@ struct CreateNoteView: View {
     @State var coordinates: CLLocationCoordinate2D
     @State private var noteText = ""
     @Binding var showNotesBox: Bool
-    var prefillDraft: NoteDraft? = nil
 
     @State private var capturedImages: [UIImage] = []
     @State private var pickedImage: UIImage?
@@ -77,12 +76,6 @@ struct CreateNoteView: View {
             .padding(.horizontal, 20)
         }
         .padding(.top, 10)
-        .onAppear {
-            if let draft = prefillDraft {
-                noteText = draft.noteText
-                capturedImages = draft.images
-            }
-        }
         .sheet(isPresented: $isCameraPresented) {
             CameraView(capturedImage: $pickedImage, isPresented: $isCameraPresented)
         }
@@ -140,12 +133,7 @@ struct CreateNoteView: View {
     /// the upload/submit runs in the background and reports back through
     /// MapViewPublisher, so the user isn't blocked waiting on it.
     func submitNote() {
-        let draft = NoteDraft(
-            id: prefillDraft?.id ?? UUID().uuidString,
-            noteText: noteText,
-            images: capturedImages,
-            coordinates: coordinates
-        )
+        let draft = NoteDraft(noteText: noteText, images: capturedImages, coordinates: coordinates)
         NotesSubmissionManager.submit(draft)
         showNotesBox = false
     }

--- a/GoInfoGame/GoInfoGame/UI/Map/CreateNoteView.swift
+++ b/GoInfoGame/GoInfoGame/UI/Map/CreateNoteView.swift
@@ -13,114 +13,140 @@ struct CreateNoteView: View {
     @State var coordinates: CLLocationCoordinate2D
     @State private var noteText = ""
     @Binding var showNotesBox: Bool
-    @State private var alertMessage = ""
-    @StateObject private var noteViewModel = NotesViewModel()
-    
-    @State var dismissSheet: (String) -> ()
-    
-    var body: some View {
-        ZStack {
-            VStack(alignment: .leading, spacing: 10) {
-                HStack {
-                    Text(L10n.Localizable.composeANote)
-                        .font(FontFamily.Lato.bold.swiftUIFont(fixedSize: 18))
-                        .foregroundStyle(Asset.Colors._42526ETextFieldText.swiftUIColor)
-                        .padding()
-                    
-                    Spacer()
-                    
-                    Button {
-                        presentationMode.wrappedValue.dismiss()
-                    } label: {
-                        Image(systemName: "xmark.circle")
-                            .font(FontFamily.Lato.bold.swiftUIFont(size: 24))
-                            .foregroundStyle(Asset.Colors._83879BTextFiledTitle.swiftUIColor)
-                            .padding()
-                    }
+    var prefillDraft: NoteDraft? = nil
 
-                }
-                
-                ZStack(alignment: .topLeading) {
-                    TextEditor(text: $noteText)
-                        .padding(2)
-                        .background(Asset.Colors.f5F5F5LightGrayBackground.swiftUIColor)
-                        .cornerRadius(8)
+    @State private var capturedImages: [UIImage] = []
+    @State private var pickedImage: UIImage?
+    @State private var isCameraPresented = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Text(L10n.Localizable.composeANote)
+                    .font(FontFamily.Lato.bold.swiftUIFont(fixedSize: 18))
+                    .foregroundStyle(Asset.Colors._42526ETextFieldText.swiftUIColor)
+                    .padding()
+
+                Spacer()
+
+                Button {
+                    presentationMode.wrappedValue.dismiss()
+                } label: {
+                    Image(systemName: "xmark.circle")
+                        .font(FontFamily.Lato.bold.swiftUIFont(size: 24))
+                        .foregroundStyle(Asset.Colors._83879BTextFiledTitle.swiftUIColor)
                         .padding()
-                    
-                    if noteText.isEmpty {
-                        Text(L10n.Localizable.composeMessage)
-                            .foregroundColor(Asset.Colors._83879BTextFiledTitle.swiftUIColor)
-                            .padding()
-                            .padding(.top, 10)
-                            .padding(.leading, 5)
-                    }
                 }
-                
-                HStack {
-                    Spacer()
-                    Button(action: {
-                        Task {
-                            do {
-                                try await submitNote()
-                            } catch {
-                                print("Error adding feature: \(error)")
-                            }
-                        }
-                    }) {
-                        if noteViewModel.isLoading {
-                            ProgressView()
-                        } else {
-                            Text("Submit")
-                                .font(FontFamily.Lato.bold.swiftUIFont(size: 20))
-                                .foregroundColor(.white)
-                                .padding()
-                                .frame(width: 156, height: 46)
-                                .background(noteText != "" ? Asset.Colors.huskyPurple.swiftUIColor : Color.gray)
-                                .cornerRadius(23)
-                        }
-                    }
-                    .disabled(noteText == "")
-                    Spacer()
-                }
-                .padding(.horizontal, 20)
+
             }
-            .padding(.top, 10)
-            
-            if noteViewModel.isLoading {
-                Color.black.opacity(0.3)
-                    .edgesIgnoringSafeArea(.all)
-               ActivityView(activityText: "Submitting Note")
+
+            ZStack(alignment: .topLeading) {
+                TextEditor(text: $noteText)
+                    .padding(2)
+                    .background(Asset.Colors.f5F5F5LightGrayBackground.swiftUIColor)
+                    .cornerRadius(8)
+                    .padding()
+
+                if noteText.isEmpty {
+                    Text(L10n.Localizable.composeMessage)
+                        .foregroundColor(Asset.Colors._83879BTextFiledTitle.swiftUIColor)
+                        .padding()
+                        .padding(.top, 10)
+                        .padding(.leading, 5)
+                }
+            }
+
+            photosSection
+
+            HStack {
+                Spacer()
+                Button(action: {
+                    submitNote()
+                }) {
+                    Text("Submit")
+                        .font(FontFamily.Lato.bold.swiftUIFont(size: 20))
+                        .foregroundColor(.white)
+                        .padding()
+                        .frame(width: 156, height: 46)
+                        .background(noteText != "" ? Asset.Colors.huskyPurple.swiftUIColor : Color.gray)
+                        .cornerRadius(23)
+                }
+                .disabled(noteText == "")
+                Spacer()
+            }
+            .padding(.horizontal, 20)
+        }
+        .padding(.top, 10)
+        .onAppear {
+            if let draft = prefillDraft {
+                noteText = draft.noteText
+                capturedImages = draft.images
+            }
+        }
+        .sheet(isPresented: $isCameraPresented) {
+            CameraView(capturedImage: $pickedImage, isPresented: $isCameraPresented)
+        }
+        .onChange(of: pickedImage) { newValue in
+            if let image = newValue {
+                capturedImages.append(image)
+                pickedImage = nil
             }
         }
     }
-    
-    func submitNote() async throws {
-        print("Note to be submitted: \(noteText)")
-        
-        do {
-          let notesResult = try await noteViewModel.createNote(note: noteText, lat: coordinates.latitude, long: coordinates.longitude)
-            
-            if notesResult {
-                print("Notes composed successfully")
-                alertMessage = "Note submitted successfully"
-                dismissSheet(alertMessage)
-                
+
+    private var photosSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Button {
+                isCameraPresented = true
+            } label: {
+                HStack {
+                    Image(systemName: "camera")
+                    Text(capturedImages.isEmpty ? "Add Photo" : "Add Another Photo")
+                }
+                .font(FontFamily.Lato.bold.swiftUIFont(size: 16))
+                .foregroundStyle(Asset.Colors.huskyPurple.swiftUIColor)
             }
-        } catch {
-            alertMessage = "Error submitting note: \(error.localizedDescription)"
-           
-            dismissSheet(alertMessage)
+            .padding(.horizontal)
+
+            if !capturedImages.isEmpty {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 10) {
+                        ForEach(Array(capturedImages.enumerated()), id: \.offset) { index, image in
+                            ZStack(alignment: .topTrailing) {
+                                Image(uiImage: image)
+                                    .resizable()
+                                    .scaledToFill()
+                                    .frame(width: 70, height: 70)
+                                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                                    .clipped()
+
+                                Button {
+                                    capturedImages.remove(at: index)
+                                } label: {
+                                    Image(systemName: "xmark.circle.fill")
+                                        .foregroundStyle(.white, .black.opacity(0.6))
+                                }
+                                .offset(x: 6, y: -6)
+                            }
+                        }
+                    }
+                    .padding(.horizontal)
+                }
+            }
         }
-        
-        await MainActor.run {
-            noteViewModel.isLoading = false
-            showNotesBox = false
-            dismissSheet(alertMessage)
-        }
+    }
+
+    /// Hands the note off to NotesSubmissionManager and closes the sheet right away —
+    /// the upload/submit runs in the background and reports back through
+    /// MapViewPublisher, so the user isn't blocked waiting on it.
+    func submitNote() {
+        let draft = NoteDraft(noteText: noteText, images: capturedImages, coordinates: coordinates)
+        NotesSubmissionManager.submit(draft)
+        showNotesBox = false
     }
 }
 
 
 #Preview {
-    CreateNoteView(coordinates: CLLocationCoordinate2D(latitude: 0.0, longitude: 0.0), showNotesBox: .constant(true), dismissSheet: {_ in })
+    CreateNoteView(coordinates: CLLocationCoordinate2D(latitude: 0.0, longitude: 0.0), showNotesBox: .constant(true))
 }

--- a/GoInfoGame/GoInfoGame/UI/Map/CreateNoteView.swift
+++ b/GoInfoGame/GoInfoGame/UI/Map/CreateNoteView.swift
@@ -140,7 +140,12 @@ struct CreateNoteView: View {
     /// the upload/submit runs in the background and reports back through
     /// MapViewPublisher, so the user isn't blocked waiting on it.
     func submitNote() {
-        let draft = NoteDraft(noteText: noteText, images: capturedImages, coordinates: coordinates)
+        let draft = NoteDraft(
+            id: prefillDraft?.id ?? UUID().uuidString,
+            noteText: noteText,
+            images: capturedImages,
+            coordinates: coordinates
+        )
         NotesSubmissionManager.submit(draft)
         showNotesBox = false
     }

--- a/GoInfoGame/GoInfoGame/UI/Map/CustomMap.swift
+++ b/GoInfoGame/GoInfoGame/UI/Map/CustomMap.swift
@@ -122,6 +122,39 @@ final class QuestClusterAnnotationView: MLNAnnotationView {
     required init?(coder: NSCoder) { super.init(coder: coder) }
 }
 
+/// Marks the coordinate a note or feature is currently being added at. Shown only
+/// while the long-press action sheet or the Create Note/Add Feature sheet that
+/// follows it is open, and removed as soon as that flow closes (submit or cancel).
+final class TemporaryPinAnnotation: NSObject, MLNAnnotation {
+    var coordinate: CLLocationCoordinate2D
+    init(coordinate: CLLocationCoordinate2D) {
+        self.coordinate = coordinate
+    }
+}
+
+final class TemporaryPinAnnotationView: MLNAnnotationView {
+    private let imageView = UIImageView()
+
+    init(reuseIdentifier: String) {
+        super.init(reuseIdentifier: reuseIdentifier)
+        let size = CGSize(width: 32, height: 40)
+        frame = CGRect(origin: .zero, size: size)
+
+        imageView.frame = bounds
+        imageView.contentMode = .scaleAspectFit
+        let config = UIImage.SymbolConfiguration(pointSize: 32, weight: .bold)
+        imageView.image = UIImage(systemName: "mappin", withConfiguration: config)
+        imageView.tintColor = Asset.Colors.ff0041Red.color
+        addSubview(imageView)
+
+        // The symbol's pointed tip sits at the bottom of its bounds — shift the view
+        // up by half its height so the tip (not the center) lands on the coordinate.
+        centerOffset = CGVector(dx: 0, dy: -size.height / 2)
+    }
+
+    required init?(coder: NSCoder) { super.init(coder: coder) }
+}
+
 // MARK: - Icon Helper
 
 private func makeCircularIcon(_ image: UIImage) -> UIImage {
@@ -176,6 +209,7 @@ struct CustomMap: UIViewRepresentable {
     @Binding var tappedCoordinate: CLLocationCoordinate2D?
     @Binding var annotationCoordinate: CLLocationCoordinate2D?
     @Binding var shadowRegions: [CoordinateBounds]
+    @Binding var pendingAdditionCoordinate: CLLocationCoordinate2D?
 
     func makeUIView(context: Context) -> MLNMapView {
         let styleURL = URL(string: "https://tiles.openfreemap.org/styles/liberty")!
@@ -236,6 +270,11 @@ struct CustomMap: UIViewRepresentable {
             context.coordinator.previousShadowRegions = shadowRegions
             context.coordinator.updateShadowOverlay(regions: shadowRegions)
         }
+
+        if pendingAdditionCoordinate != context.coordinator.previousNoteBeingAddedCoordinate {
+            context.coordinator.previousNoteBeingAddedCoordinate = pendingAdditionCoordinate
+            context.coordinator.updateNoteBeingAddedAnnotation(coordinate: pendingAdditionCoordinate)
+        }
     }
 
     func makeCoordinator() -> Coordinator { Coordinator(self) }
@@ -260,6 +299,8 @@ struct CustomMap: UIViewRepresentable {
 
         var previousLineCoordinates: [CLLocationCoordinate2D] = []
         var previousShadowRegions: [CoordinateBounds] = []
+        var previousNoteBeingAddedCoordinate: CLLocationCoordinate2D?
+        private var pendingAdditionAnnotation: TemporaryPinAnnotation?
 
         let shadowSourceId   = "shadow-source"
         let shadowLayerId    = "shadow-layer"
@@ -303,6 +344,12 @@ struct CustomMap: UIViewRepresentable {
                            ?? QuestClusterAnnotationView(reuseIdentifier: "cluster")
                 view.count = cluster.memberAnnotations.count
                 return view
+            }
+
+            if annotation is TemporaryPinAnnotation {
+                let reuseId = "note-being-added"
+                return (mapView.dequeueReusableAnnotationView(withIdentifier: reuseId) as? TemporaryPinAnnotationView)
+                       ?? TemporaryPinAnnotationView(reuseIdentifier: reuseId)
             }
 
             if let quest = annotation as? DisplayUnitAnnotation {
@@ -638,6 +685,17 @@ struct CustomMap: UIViewRepresentable {
 
                 DispatchQueue.main.async { src.shape = polygon }
             }
+        }
+
+        func updateNoteBeingAddedAnnotation(coordinate: CLLocationCoordinate2D?) {
+            if let existing = pendingAdditionAnnotation {
+                mapView?.removeAnnotation(existing)
+                pendingAdditionAnnotation = nil
+            }
+            guard let coordinate else { return }
+            let annotation = TemporaryPinAnnotation(coordinate: coordinate)
+            pendingAdditionAnnotation = annotation
+            mapView?.addAnnotation(annotation)
         }
 
         func updateUserRegion(_ mapView: MLNMapView) {

--- a/GoInfoGame/GoInfoGame/UI/Map/CustomMap.swift
+++ b/GoInfoGame/GoInfoGame/UI/Map/CustomMap.swift
@@ -513,13 +513,19 @@ struct CustomMap: UIViewRepresentable {
                 visited.insert(i)
 
                 var group = [annotations[i]]
-                let ptI = points[i]
+                var sumX = points[i].x
+                var sumY = points[i].y
 
                 for j in (i + 1)..<annotations.count {
                     if visited.contains(j) { continue }
-                    if hypot(ptI.x - points[j].x, ptI.y - points[j].y) < radius {
+                    let n = CGFloat(group.count)
+                    let centroidX = sumX / n
+                    let centroidY = sumY / n
+                    if hypot(centroidX - points[j].x, centroidY - points[j].y) < radius {
                         group.append(annotations[j])
                         visited.insert(j)
+                        sumX += points[j].x
+                        sumY += points[j].y
                     }
                 }
 

--- a/GoInfoGame/GoInfoGame/UI/Map/MapView.swift
+++ b/GoInfoGame/GoInfoGame/UI/Map/MapView.swift
@@ -35,6 +35,7 @@ struct MapView: View {
 
     @State private var tappedCoordinate: CLLocationCoordinate2D? = nil
     @State private var annotationCoordinate: CLLocationCoordinate2D? = nil
+    @State private var pendingAdditionCoordinate: CLLocationCoordinate2D? = nil
     @State private var showMapLongPressedSheet = false
     @State private var showAddFeatureSheet = false
     @State private var showCreateNoteSheet = false
@@ -52,8 +53,6 @@ struct MapView: View {
     @State private var showFilterQuestsSheet = false
     @State private var showElemntDeletedAlert = false
     @State private var activeConflict: PendingSyncConflict?
-    @State private var failedNoteDraft: NoteDraft?
-    @State private var noteDraftPrefill: NoteDraft?
 
     /// The sync button spins whenever either queue (failed quest elements or
     /// pending notes) is actively being drained, whichever started it.
@@ -90,11 +89,16 @@ struct MapView: View {
                     },
                     tappedCoordinate: $tappedCoordinate,
                     annotationCoordinate: $annotationCoordinate,
-                    shadowRegions: $shadowRegions
+                    shadowRegions: $shadowRegions,
+                    pendingAdditionCoordinate: $pendingAdditionCoordinate
                 )
                 .accessibilityHidden(enableAccessibility)
                 .onChange(of: tappedCoordinate) { _ in
                     showMapLongPressedSheet = tappedCoordinate != nil
+                    pendingAdditionCoordinate = tappedCoordinate
+                    if let coordinate = tappedCoordinate {
+                        ensureCoordinateVisibleAboveSheet(coordinate)
+                    }
                 }
                 .onChange(of: viewModel.selectedQuest) { _ in
                     shouldShowPolyline = false
@@ -122,11 +126,6 @@ struct MapView: View {
                             .frame(maxWidth: .infinity)
                             .background(Asset.Colors.huskyPurple.swiftUIColor)
                             .cornerRadius(12)
-                        if failedNoteDraft != nil {
-                            Text("Tap to retry")
-                                .foregroundColor(.white.opacity(0.8))
-                                .font(.system(size: 13, weight: .semibold))
-                        }
                     }
                     .padding(24)
                     .frame(maxWidth: 350)
@@ -136,17 +135,9 @@ struct MapView: View {
                             .shadow(color: .black.opacity(0.1), radius: 10, x: 0, y: 4)
                     )
                     .accessibilityElement(children: .combine)
-                    .accessibilityLabel(failedNoteDraft != nil ? "\(alertMessage). Tap to retry." : alertMessage)
-                    .onTapGesture {
-                        guard let draft = failedNoteDraft else { return }
-                        failedNoteDraft = nil
-                        showAlert = false
-                        noteDraftPrefill = draft
-                        showCreateNoteSheet = true
-                    }
+                    .accessibilityLabel(alertMessage)
                     .onAppear {
-                        let dismissDelay: Double = failedNoteDraft != nil ? 5 : 2
-                        DispatchQueue.main.asyncAfter(deadline: .now() + dismissDelay) { showAlert = false }
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 2) { showAlert = false }
                     }
                 }
 
@@ -312,7 +303,6 @@ struct MapView: View {
                             guard viewModel.syncFailedElementsCount > 0 || viewModel.pendingNotesCount > 0 else {
                                 alertIcon = "info.bubble"
                                 alertMessage = "No elements to sync"
-                                failedNoteDraft = nil
                                 showAlert = true
                                 return
                             }
@@ -491,15 +481,31 @@ struct MapView: View {
                 .presentationDetents([.fraction(0.2)])
                 .presentationDragIndicator(.visible)
                 .applyPresentationSizingPage()
+                .onDisappear {
+                    // Covers swipe-to-dismiss without picking either option — if neither
+                    // follow-up sheet ends up opening, the pin has nothing left to mark.
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
+                        if !showCreateNoteSheet && !showAddFeatureSheet {
+                            pendingAdditionCoordinate = nil
+                        }
+                    }
+                }
             }
         }
         .sheet(isPresented: $showCreateNoteSheet) {
             CreateNoteView(
-                coordinates: noteDraftPrefill?.coordinates ?? tappedCoordinate ?? CLLocationCoordinate2D(),
-                showNotesBox: $showCreateNoteSheet,
-                prefillDraft: noteDraftPrefill
+                coordinates: tappedCoordinate ?? CLLocationCoordinate2D(),
+                showNotesBox: $showCreateNoteSheet
             )
-            .onDisappear { noteDraftPrefill = nil }
+            .onAppear {
+                pendingAdditionCoordinate = tappedCoordinate
+                if let coordinate = tappedCoordinate {
+                    ensureCoordinateVisibleAboveSheet(coordinate)
+                }
+            }
+            .onDisappear {
+                pendingAdditionCoordinate = nil
+            }
             .presentationDetents([.fraction(0.6)])
             .presentationDragIndicator(.visible)
             .applyPresentationSizingPage()
@@ -513,10 +519,18 @@ struct MapView: View {
                         ? "exclamationmark.triangle.fill"
                         : "checkmark.circle.fill"
                     alertMessage = message
-                    failedNoteDraft = nil
                     showAlert = true
                 }
             )
+            .onAppear {
+                pendingAdditionCoordinate = tappedCoordinate
+                if let coordinate = tappedCoordinate {
+                    ensureCoordinateVisibleAboveSheet(coordinate)
+                }
+            }
+            .onDisappear {
+                pendingAdditionCoordinate = nil
+            }
             .presentationDetents([.fraction(0.6)])
             .presentationDragIndicator(.visible)
             .applyPresentationSizingPage()
@@ -558,13 +572,6 @@ struct MapView: View {
             case .noteSubmitted:
                 alertIcon = "checkmark.circle.fill"
                 alertMessage = "Note submitted successfully"
-                failedNoteDraft = nil
-                showAlert = true
-                viewModel.checkSyncStatus()
-            case .noteSubmissionFailed(let message, let draft):
-                alertIcon = "exclamationmark.triangle.fill"
-                alertMessage = message
-                failedNoteDraft = draft
                 showAlert = true
                 viewModel.checkSyncStatus()
             case .notesQueueUpdated:
@@ -604,6 +611,30 @@ struct MapView: View {
     }
 
     // MARK: – Helpers
+
+    /// Both the long-press action sheet and the Create Note/Add Feature sheets that
+    /// follow it use a 0.6-fraction bottom sheet at most — panning for that worst case
+    /// up front means the pin never gets covered as the user moves between them.
+    private static let noteSheetHeightFraction: CGFloat = 0.6
+
+    /// If `coordinate` would currently be hidden behind the bottom sheet, pans the map
+    /// just enough to bring it into the remaining visible band above the sheet.
+    func ensureCoordinateVisibleAboveSheet(_ coordinate: CLLocationCoordinate2D) {
+        guard let mapView = mapViewRef else { return }
+        let sheetHeight = mapView.bounds.height * Self.noteSheetHeightFraction
+        let visibleHeight = mapView.bounds.height - sheetHeight
+        guard visibleHeight > 0 else { return }
+
+        let point = mapView.convert(coordinate, toPointTo: mapView)
+        guard point.y > visibleHeight else { return } // already clear of the sheet
+
+        let targetY = visibleHeight / 2
+        let deltaY = point.y - targetY
+        let currentCenterPoint = CGPoint(x: mapView.bounds.midX, y: mapView.bounds.midY)
+        let shiftedPoint = CGPoint(x: currentCenterPoint.x, y: currentCenterPoint.y + deltaY)
+        let newCenter = mapView.convert(shiftedPoint, toCoordinateFrom: mapView)
+        mapView.setCenter(newCenter, animated: true)
+    }
 
     func voiceOverAnnounce(message: String) {
         guard isVoiceOverOn else { return }
@@ -877,7 +908,6 @@ public enum SheetDismissalScenario {
     case undoDone(String)
     case syncBackground(Int)
     case noteSubmitted
-    case noteSubmissionFailed(String, NoteDraft)
     case notesQueueUpdated
     case notesSyncing
     case notesSyncFinished

--- a/GoInfoGame/GoInfoGame/UI/Map/MapView.swift
+++ b/GoInfoGame/GoInfoGame/UI/Map/MapView.swift
@@ -21,7 +21,8 @@ struct MapView: View {
 
     @State private var shouldShowPolyline = true
     @State private var lineCoordinates: [CLLocationCoordinate2D] = []
-    @State private var isSyncing = false
+    @State private var isSyncingElements = false
+    @State private var isSyncingNotes = false
     @State private var showAlert = false
     @State private var alertMessage = ""
     @State private var alertIcon = ""
@@ -53,6 +54,10 @@ struct MapView: View {
     @State private var activeConflict: PendingSyncConflict?
     @State private var failedNoteDraft: NoteDraft?
     @State private var noteDraftPrefill: NoteDraft?
+
+    /// The sync button spins whenever either queue (failed quest elements or
+    /// pending notes) is actively being drained, whichever started it.
+    private var isSyncing: Bool { isSyncingElements || isSyncingNotes }
 
     var body: some View {
         NavigationStack {
@@ -301,19 +306,25 @@ struct MapView: View {
                     accessbilityButton
 
                     QuestSyncButton(
-                        badgeCount: viewModel.syncFailedElementsCount,
+                        badgeCount: viewModel.syncFailedElementsCount + viewModel.pendingNotesCount,
                         isSyncing: isSyncing,
                         action: {
-                            guard viewModel.syncFailedElementsCount > 0 else {
+                            guard viewModel.syncFailedElementsCount > 0 || viewModel.pendingNotesCount > 0 else {
                                 alertIcon = "info.bubble"
                                 alertMessage = "No elements to sync"
                                 failedNoteDraft = nil
                                 showAlert = true
                                 return
                             }
-                            isSyncing = true
+
+                            if viewModel.pendingNotesCount > 0 {
+                                NotesSubmissionManager.resumePendingUploads()
+                            }
+
+                            guard viewModel.syncFailedElementsCount > 0 else { return }
+                            isSyncingElements = true
                             DatasyncManager.shared.syncDataToOSM(exclude_gig_tags: false) { _ in
-                                isSyncing = false
+                                isSyncingElements = false
                                 viewModel.checkSyncStatus()
                             }
                         }
@@ -527,12 +538,12 @@ struct MapView: View {
             case .dismissed:
                 shouldShowPolyline = false
             case .syncing:
-                isSyncing = true
+                isSyncingElements = true
             case .synced:
-                isSyncing = false
+                isSyncingElements = false
                 viewModel.checkSyncStatus()
             case .failed:
-                isSyncing = false
+                isSyncingElements = false
                 shouldShowPolyline = false
                 viewModel.checkSyncStatus()
             case .hideElement(let elementId, let elementName):
@@ -549,11 +560,20 @@ struct MapView: View {
                 alertMessage = "Note submitted successfully"
                 failedNoteDraft = nil
                 showAlert = true
+                viewModel.checkSyncStatus()
             case .noteSubmissionFailed(let message, let draft):
                 alertIcon = "exclamationmark.triangle.fill"
                 alertMessage = message
                 failedNoteDraft = draft
                 showAlert = true
+                viewModel.checkSyncStatus()
+            case .notesQueueUpdated:
+                viewModel.checkSyncStatus()
+            case .notesSyncing:
+                isSyncingNotes = true
+            case .notesSyncFinished:
+                isSyncingNotes = false
+                viewModel.checkSyncStatus()
             }
         }
         .onReceive(QuestsPublisher.shared.refreshQuest) { _ in
@@ -858,6 +878,9 @@ public enum SheetDismissalScenario {
     case syncBackground(Int)
     case noteSubmitted
     case noteSubmissionFailed(String, NoteDraft)
+    case notesQueueUpdated
+    case notesSyncing
+    case notesSyncFinished
 }
 
 class ContextualInfo: ObservableObject {

--- a/GoInfoGame/GoInfoGame/UI/Map/MapView.swift
+++ b/GoInfoGame/GoInfoGame/UI/Map/MapView.swift
@@ -51,6 +51,8 @@ struct MapView: View {
     @State private var showFilterQuestsSheet = false
     @State private var showElemntDeletedAlert = false
     @State private var activeConflict: PendingSyncConflict?
+    @State private var failedNoteDraft: NoteDraft?
+    @State private var noteDraftPrefill: NoteDraft?
 
     var body: some View {
         NavigationStack {
@@ -115,6 +117,11 @@ struct MapView: View {
                             .frame(maxWidth: .infinity)
                             .background(Asset.Colors.huskyPurple.swiftUIColor)
                             .cornerRadius(12)
+                        if failedNoteDraft != nil {
+                            Text("Tap to retry")
+                                .foregroundColor(.white.opacity(0.8))
+                                .font(.system(size: 13, weight: .semibold))
+                        }
                     }
                     .padding(24)
                     .frame(maxWidth: 350)
@@ -124,9 +131,17 @@ struct MapView: View {
                             .shadow(color: .black.opacity(0.1), radius: 10, x: 0, y: 4)
                     )
                     .accessibilityElement(children: .combine)
-                    .accessibilityLabel(alertMessage)
+                    .accessibilityLabel(failedNoteDraft != nil ? "\(alertMessage). Tap to retry." : alertMessage)
+                    .onTapGesture {
+                        guard let draft = failedNoteDraft else { return }
+                        failedNoteDraft = nil
+                        showAlert = false
+                        noteDraftPrefill = draft
+                        showCreateNoteSheet = true
+                    }
                     .onAppear {
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 2) { showAlert = false }
+                        let dismissDelay: Double = failedNoteDraft != nil ? 5 : 2
+                        DispatchQueue.main.asyncAfter(deadline: .now() + dismissDelay) { showAlert = false }
                     }
                 }
 
@@ -292,6 +307,7 @@ struct MapView: View {
                             guard viewModel.syncFailedElementsCount > 0 else {
                                 alertIcon = "info.bubble"
                                 alertMessage = "No elements to sync"
+                                failedNoteDraft = nil
                                 showAlert = true
                                 return
                             }
@@ -468,16 +484,11 @@ struct MapView: View {
         }
         .sheet(isPresented: $showCreateNoteSheet) {
             CreateNoteView(
-                coordinates: tappedCoordinate ?? CLLocationCoordinate2D(),
+                coordinates: noteDraftPrefill?.coordinates ?? tappedCoordinate ?? CLLocationCoordinate2D(),
                 showNotesBox: $showCreateNoteSheet,
-                dismissSheet: { message in
-                    alertIcon = message.contains("Error")
-                        ? "exclamationmark.triangle.fill"
-                        : "checkmark.circle.fill"
-                    alertMessage = message
-                    showAlert = true
-                }
+                prefillDraft: noteDraftPrefill
             )
+            .onDisappear { noteDraftPrefill = nil }
             .presentationDetents([.fraction(0.6)])
             .presentationDragIndicator(.visible)
             .applyPresentationSizingPage()
@@ -491,6 +502,7 @@ struct MapView: View {
                         ? "exclamationmark.triangle.fill"
                         : "checkmark.circle.fill"
                     alertMessage = message
+                    failedNoteDraft = nil
                     showAlert = true
                 }
             )
@@ -532,6 +544,16 @@ struct MapView: View {
             case .syncBackground(let elementID):
                 shouldShowPolyline = false
                 viewModel.refreshMapAfterSubmission(elementId: elementID)
+            case .noteSubmitted:
+                alertIcon = "checkmark.circle.fill"
+                alertMessage = "Note submitted successfully"
+                failedNoteDraft = nil
+                showAlert = true
+            case .noteSubmissionFailed(let message, let draft):
+                alertIcon = "exclamationmark.triangle.fill"
+                alertMessage = message
+                failedNoteDraft = draft
+                showAlert = true
             }
         }
         .onReceive(QuestsPublisher.shared.refreshQuest) { _ in
@@ -834,6 +856,8 @@ public enum SheetDismissalScenario {
     case hideElement(String, String)
     case undoDone(String)
     case syncBackground(Int)
+    case noteSubmitted
+    case noteSubmissionFailed(String, NoteDraft)
 }
 
 class ContextualInfo: ObservableObject {

--- a/GoInfoGame/GoInfoGame/UI/Map/MapViewModel.swift
+++ b/GoInfoGame/GoInfoGame/UI/Map/MapViewModel.swift
@@ -38,6 +38,7 @@ class MapViewModel: ObservableObject {
     @Published var selectedOption: SatelliteOption = .none
     @Published var showSatellitePicker: Bool = false
     @Published private(set) var syncFailedElementsCount: Int = 0
+    @Published private(set) var pendingNotesCount: Int = 0
     let workspace: Workspace
 
     init(workspace: Workspace) {
@@ -54,6 +55,7 @@ class MapViewModel: ObservableObject {
 
     func checkSyncStatus() {
         self.syncFailedElementsCount = dbInstance.getChangesets(synced: false).count
+        self.pendingNotesCount = dbInstance.pendingNoteDraftsCount()
     }
 
     func sattiliteServersFor(point: CLLocationCoordinate2D) -> [SatelliteServer] {

--- a/GoInfoGame/GoInfoGame/UI/Map/NotesSubmissionManager.swift
+++ b/GoInfoGame/GoInfoGame/UI/Map/NotesSubmissionManager.swift
@@ -1,0 +1,72 @@
+//
+//  NotesSubmissionManager.swift
+//  GoInfoGame
+//
+
+import Foundation
+import UIKit
+import CoreLocation
+
+/// Everything needed to (re)attempt a note submission, kept around so a failed
+/// background submission can be handed back to CreateNoteView for a retry.
+public struct NoteDraft {
+    var noteText: String
+    var images: [UIImage]
+    var coordinates: CLLocationCoordinate2D
+}
+
+/// Submits notes (and their Kartaview photo uploads) outside the lifetime of
+/// CreateNoteView, so the sheet can dismiss immediately after Submit is tapped.
+/// Results are reported through MapViewPublisher.shared.dismissSheet, the same
+/// channel quest submissions use for background sync notifications.
+enum NotesSubmissionManager {
+    static func submit(_ draft: NoteDraft) {
+        Task.detached(priority: .userInitiated) {
+            do {
+                var finalNoteText = draft.noteText
+
+                if !draft.images.isEmpty {
+                    let photoURLs = try await uploadPhotos(draft.images)
+                    finalNoteText += "\n\n" + photoURLs.joined(separator: "\n")
+                }
+
+                let result = try await NotesViewModel().createNote(
+                    note: finalNoteText,
+                    lat: draft.coordinates.latitude,
+                    long: draft.coordinates.longitude
+                )
+
+                await MainActor.run {
+                    if result {
+                        MapViewPublisher.shared.dismissSheet.send(.noteSubmitted)
+                    } else {
+                        MapViewPublisher.shared.dismissSheet.send(.noteSubmissionFailed("Error submitting note", draft))
+                    }
+                }
+            } catch {
+                await MainActor.run {
+                    MapViewPublisher.shared.dismissSheet.send(.noteSubmissionFailed("Error submitting note: \(error.localizedDescription)", draft))
+                }
+            }
+        }
+    }
+
+    private static func uploadPhotos(_ images: [UIImage]) async throws -> [String] {
+        var urls: [String] = []
+
+        for (index, image) in images.enumerated() {
+            do {
+                let url = try await KartaviewViewModel(capturedImage: image).uploadAsync()
+                urls.append(url)
+            } catch {
+                throw NSError(
+                    domain: "KartaviewUpload",
+                    code: 0,
+                    userInfo: [NSLocalizedDescriptionKey: "Failed to upload photo \(index + 1) to Kartaview: \(error.localizedDescription)"]
+                )
+            }
+        }
+
+        return urls
+    }
+}

--- a/GoInfoGame/GoInfoGame/UI/Map/NotesSubmissionManager.swift
+++ b/GoInfoGame/GoInfoGame/UI/Map/NotesSubmissionManager.swift
@@ -7,10 +7,8 @@ import Foundation
 import UIKit
 import CoreLocation
 
-/// Everything needed to (re)attempt a note submission, kept around so a failed
-/// background submission can be handed back to CreateNoteView for a retry.
-/// `id` ties a draft to its persisted StoredNoteDraft row, so resubmitting an
-/// edited retry updates the existing queued note instead of creating a duplicate.
+/// Everything needed to submit a note. `id` ties it to its persisted StoredNoteDraft
+/// row so NotesSubmissionManager can upsert/delete the right queue entry.
 public struct NoteDraft {
     public var id: String = UUID().uuidString
     var noteText: String
@@ -61,6 +59,8 @@ enum NotesSubmissionManager {
         }
     }
 
+    /// A failed attempt is never surfaced to the user — the note stays queued
+    /// (already reflected in the sync badge) and is retried by the next trigger.
     fileprivate static func attempt(_ record: StoredNoteDraftSnapshot) async {
         do {
             let images = record.imagePaths.compactMap { NoteImageStorage.shared.load(path: $0) }
@@ -84,19 +84,10 @@ enum NotesSubmissionManager {
                     MapViewPublisher.shared.dismissSheet.send(.noteSubmitted)
                 }
             } else {
-                await fail(record, images: images, message: "Error submitting note")
+                DatabaseConnector.shared.markNoteDraftFailed(id: record.id, error: "Error submitting note")
             }
         } catch {
-            let images = record.imagePaths.compactMap { NoteImageStorage.shared.load(path: $0) }
-            await fail(record, images: images, message: "Error submitting note: \(error.localizedDescription)")
-        }
-    }
-
-    private static func fail(_ record: StoredNoteDraftSnapshot, images: [UIImage], message: String) async {
-        DatabaseConnector.shared.markNoteDraftFailed(id: record.id, error: message)
-        let draft = NoteDraft(id: record.id, noteText: record.noteText, images: images, coordinates: record.coordinates)
-        await MainActor.run {
-            MapViewPublisher.shared.dismissSheet.send(.noteSubmissionFailed(message, draft))
+            DatabaseConnector.shared.markNoteDraftFailed(id: record.id, error: error.localizedDescription)
         }
     }
 
@@ -105,7 +96,13 @@ enum NotesSubmissionManager {
 
         for (index, image) in images.enumerated() {
             do {
-                let url = try await KartaviewViewModel(capturedImage: image).uploadAsync()
+                // KartaviewViewModel creates a CLLocationManager on init and immediately
+                // calls requestWhenInUseAuthorization()/startUpdating*() — CoreLocation
+                // requires those to happen on a thread with an active run loop (main),
+                // or the app-level authorization handshake stalls. Only construction
+                // needs the hop; the network upload itself is fine off the main thread.
+                let viewModel = await MainActor.run { KartaviewViewModel(capturedImage: image) }
+                let url = try await viewModel.uploadAsync()
                 urls.append(url)
             } catch {
                 throw NSError(

--- a/GoInfoGame/GoInfoGame/UI/Map/NotesSubmissionManager.swift
+++ b/GoInfoGame/GoInfoGame/UI/Map/NotesSubmissionManager.swift
@@ -9,7 +9,10 @@ import CoreLocation
 
 /// Everything needed to (re)attempt a note submission, kept around so a failed
 /// background submission can be handed back to CreateNoteView for a retry.
+/// `id` ties a draft to its persisted StoredNoteDraft row, so resubmitting an
+/// edited retry updates the existing queued note instead of creating a duplicate.
 public struct NoteDraft {
+    public var id: String = UUID().uuidString
     var noteText: String
     var images: [UIImage]
     var coordinates: CLLocationCoordinate2D
@@ -17,37 +20,83 @@ public struct NoteDraft {
 
 /// Submits notes (and their Kartaview photo uploads) outside the lifetime of
 /// CreateNoteView, so the sheet can dismiss immediately after Submit is tapped.
+/// Every draft is persisted (text + photos on disk, metadata in Realm) *before* any
+/// network call, so a note captured offline — or one whose upload gets interrupted —
+/// survives an app kill and stays queued until it's retried, either automatically
+/// (submit, app foreground/launch) or manually via the sync button.
 /// Results are reported through MapViewPublisher.shared.dismissSheet, the same
 /// channel quest submissions use for background sync notifications.
 enum NotesSubmissionManager {
+
+    /// Persists the draft, then drains the whole pending queue (not just this
+    /// draft), so any earlier notes that failed get swept up too.
     static func submit(_ draft: NoteDraft) {
         Task.detached(priority: .userInitiated) {
-            do {
-                var finalNoteText = draft.noteText
-
-                if !draft.images.isEmpty {
-                    let photoURLs = try await uploadPhotos(draft.images)
-                    finalNoteText += "\n\n" + photoURLs.joined(separator: "\n")
-                }
-
-                let result = try await NotesViewModel().createNote(
-                    note: finalNoteText,
-                    lat: draft.coordinates.latitude,
-                    long: draft.coordinates.longitude
-                )
-
-                await MainActor.run {
-                    if result {
-                        MapViewPublisher.shared.dismissSheet.send(.noteSubmitted)
-                    } else {
-                        MapViewPublisher.shared.dismissSheet.send(.noteSubmissionFailed("Error submitting note", draft))
-                    }
-                }
-            } catch {
-                await MainActor.run {
-                    MapViewPublisher.shared.dismissSheet.send(.noteSubmissionFailed("Error submitting note: \(error.localizedDescription)", draft))
-                }
+            let previousPaths = DatabaseConnector.shared.noteDraftImagePaths(id: draft.id)
+            if !previousPaths.isEmpty {
+                NoteImageStorage.shared.delete(paths: previousPaths)
             }
+
+            let imagePaths = draft.images.compactMap { try? NoteImageStorage.shared.save($0) }
+            DatabaseConnector.shared.upsertNoteDraft(
+                id: draft.id,
+                noteText: draft.noteText,
+                imagePaths: imagePaths,
+                coordinates: draft.coordinates
+            )
+
+            await MainActor.run {
+                MapViewPublisher.shared.dismissSheet.send(.notesQueueUpdated)
+            }
+
+            await NotesQueueProcessor.shared.processPending()
+        }
+    }
+
+    /// Resumes uploading whatever notes are still queued. Called from the sync
+    /// button and on app foreground/launch.
+    static func resumePendingUploads() {
+        Task.detached(priority: .userInitiated) {
+            await NotesQueueProcessor.shared.processPending()
+        }
+    }
+
+    fileprivate static func attempt(_ record: StoredNoteDraftSnapshot) async {
+        do {
+            let images = record.imagePaths.compactMap { NoteImageStorage.shared.load(path: $0) }
+            var finalNoteText = record.noteText
+
+            if !images.isEmpty {
+                let photoURLs = try await uploadPhotos(images)
+                finalNoteText += "\n\n" + photoURLs.joined(separator: "\n")
+            }
+
+            let result = try await NotesViewModel().createNote(
+                note: finalNoteText,
+                lat: record.coordinates.latitude,
+                long: record.coordinates.longitude
+            )
+
+            if result {
+                DatabaseConnector.shared.deleteNoteDraft(id: record.id)
+                NoteImageStorage.shared.delete(paths: record.imagePaths)
+                await MainActor.run {
+                    MapViewPublisher.shared.dismissSheet.send(.noteSubmitted)
+                }
+            } else {
+                await fail(record, images: images, message: "Error submitting note")
+            }
+        } catch {
+            let images = record.imagePaths.compactMap { NoteImageStorage.shared.load(path: $0) }
+            await fail(record, images: images, message: "Error submitting note: \(error.localizedDescription)")
+        }
+    }
+
+    private static func fail(_ record: StoredNoteDraftSnapshot, images: [UIImage], message: String) async {
+        DatabaseConnector.shared.markNoteDraftFailed(id: record.id, error: message)
+        let draft = NoteDraft(id: record.id, noteText: record.noteText, images: images, coordinates: record.coordinates)
+        await MainActor.run {
+            MapViewPublisher.shared.dismissSheet.send(.noteSubmissionFailed(message, draft))
         }
     }
 
@@ -68,5 +117,38 @@ enum NotesSubmissionManager {
         }
 
         return urls
+    }
+}
+
+/// Serializes queue drains so a manual sync-button tap and an automatic
+/// foreground/launch resume can never process the same pending note twice at once.
+/// A single pass snapshots the queue and attempts each item once — a note that's
+/// still failing (e.g. no connectivity) is left pending for the next trigger rather
+/// than retried in a tight loop.
+private actor NotesQueueProcessor {
+    static let shared = NotesQueueProcessor()
+
+    private var isProcessing = false
+
+    func processPending() async {
+        guard !isProcessing else { return }
+
+        let pending = DatabaseConnector.shared.pendingNoteDrafts()
+        guard !pending.isEmpty else { return }
+
+        isProcessing = true
+        defer { isProcessing = false }
+
+        await MainActor.run {
+            MapViewPublisher.shared.dismissSheet.send(.notesSyncing)
+        }
+
+        for record in pending {
+            await NotesSubmissionManager.attempt(record)
+        }
+
+        await MainActor.run {
+            MapViewPublisher.shared.dismissSheet.send(.notesSyncFinished)
+        }
     }
 }


### PR DESCRIPTION
Ticket: https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/3921

Notes can now include multiple photos (camera capture), with thumbnail preview and delete before submitting. Photos are uploaded to Kartaview on submit, and their URLs are appended to the note text.
Note submission runs entirely in the background — the Create Note sheet dismisses immediately on Submit instead of blocking on the network.
Added offline support for notes: pending notes and their photos are persisted (Realm + on-disk files) so they survive an app kill, and are retried automatically on submit, app foreground, and via the sync button. A failed attempt is silent — no error popup, it just stays queued.
The sync button badge now shows pending notes alongside failed quest syncs, and spins while either is draining.
Added a temporary map pin marking the long-pressed location while the Create Note/Add Feature flow is open, positioned so the bottom sheet never covers it.
Fixed ApiManager using an unbounded (infinite) request timeout, which could leave the quest-loading spinner and the notes queue's processing lock stuck forever on a hung connection; JSON requests now time out at 60s.




https://github.com/user-attachments/assets/b41e327b-c62d-4f9d-af81-1d6ef15c398c

