### PR TITLE
BUG-4046: Fixed navigation title issue when user coming from profile screen

### DIFF
--- a/GoInfoGame/GoInfoGame/UI/Map/CustomMap.swift
+++ b/GoInfoGame/GoInfoGame/UI/Map/CustomMap.swift
@@ -275,9 +275,16 @@ struct CustomMap: UIViewRepresentable {
     /// Zoom level captured just before zooming in on a selected quest; MapView restores
     /// it once the quest sheet is dismissed. `nil` when no quest-driven zoom is active.
     @Binding var previousZoomLevel: Double?
+    /// Camera center captured alongside `previousZoomLevel`, so MapView can restore the
+    /// whole camera (not just zoom) once the quest sheet is dismissed.
+    @Binding var previousCenter: CLLocationCoordinate2D?
     /// Nudges the map so `coordinate` clears the quest sheet, called once the
     /// select-a-quest zoom/pan animation finishes.
     var ensureQuestVisibleAboveSheet: ((CLLocationCoordinate2D) -> Void)?
+    /// Edge padding to use when fitting a selected way's full path in view — the
+    /// bottom side accounts for the quest sheet, sized by MapView (the single source
+    /// of truth for the sheet's on-screen height).
+    var questPathEdgePadding: (() -> UIEdgeInsets)?
 
     func makeUIView(context: Context) -> MLNMapView {
         // Bundled StreetComplete style — shared with the Android app so both
@@ -975,6 +982,35 @@ struct CustomMap: UIViewRepresentable {
             }
         }
 
+        /// Fits the full path (plus the tapped point, in case it isn't exactly on the
+        /// line) in view with padding, capping the zoom-in at 19 — unless the user was
+        /// already zoomed in past 19 before selecting, in which case their closer zoom
+        /// is respected instead of forcing the view back out to fit the whole path.
+        private func fitPath(_ pathCoordinates: [CLLocationCoordinate2D],
+                             focusCoordinate: CLLocationCoordinate2D,
+                             mapView: MLNMapView,
+                             previousZoom: Double) {
+            var minLat = focusCoordinate.latitude, maxLat = focusCoordinate.latitude
+            var minLon = focusCoordinate.longitude, maxLon = focusCoordinate.longitude
+            for coordinate in pathCoordinates {
+                minLat = min(minLat, coordinate.latitude)
+                maxLat = max(maxLat, coordinate.latitude)
+                minLon = min(minLon, coordinate.longitude)
+                maxLon = max(maxLon, coordinate.longitude)
+            }
+            let bounds = MLNCoordinateBounds(
+                sw: CLLocationCoordinate2D(latitude: minLat, longitude: minLon),
+                ne: CLLocationCoordinate2D(latitude: maxLat, longitude: maxLon)
+            )
+            let padding = parent.questPathEdgePadding?()
+                ?? UIEdgeInsets(top: 60, left: 40, bottom: 40, right: 40)
+
+            mapView.setVisibleCoordinateBounds(bounds, edgePadding: padding, animated: true) {
+                guard previousZoom <= 19, mapView.zoomLevel > 19 else { return }
+                mapView.setZoomLevel(min(19, mapView.maximumZoomLevel), animated: true)
+            }
+        }
+
         private func handleSingleSelect(annotation: DisplayUnitAnnotation,
                                         coordinate: CLLocationCoordinate2D) {
             DispatchQueue.main.async {
@@ -982,7 +1018,8 @@ struct CustomMap: UIViewRepresentable {
                 self.parent.selectedQuest = annotation.displayUnit
                 self.parent.isPresented = true
 
-                if let polyline = annotation.displayUnit?.parent?.polylines {
+                let polyline = annotation.displayUnit?.parent?.polylines
+                if let polyline {
                     self.parent.lineCoordinates = polyline
                     self.parent.shouldShowPolyline = true
                 } else {
@@ -990,16 +1027,24 @@ struct CustomMap: UIViewRepresentable {
                 }
 
                 if let mapView = self.mapView {
-                    // Remember the zoom level as it was before this quest was picked —
+                    // Remember the camera as it was before this quest was picked —
                     // MapView restores it once the sheet is cancelled or submitted.
                     if self.parent.previousZoomLevel == nil {
                         self.parent.previousZoomLevel = mapView.zoomLevel
+                        self.parent.previousCenter = mapView.centerCoordinate
                     }
-                    let targetZoom = min(19, mapView.maximumZoomLevel)
-                    mapView.setCenter(coordinate, zoomLevel: targetZoom, direction: -1, animated: true) {
-                        // Nudge only after the zoom/pan settles — the sheet-clearance
-                        // math needs the post-zoom camera to convert coordinates correctly.
-                        self.parent.ensureQuestVisibleAboveSheet?(coordinate)
+                    let previousZoom = self.parent.previousZoomLevel ?? mapView.zoomLevel
+
+                    if let polyline, polyline.count > 1 {
+                        self.fitPath(polyline, focusCoordinate: coordinate,
+                                    mapView: mapView, previousZoom: previousZoom)
+                    } else {
+                        let targetZoom = min(19, mapView.maximumZoomLevel)
+                        mapView.setCenter(coordinate, zoomLevel: targetZoom, direction: -1, animated: true) {
+                            // Nudge only after the zoom/pan settles — the sheet-clearance
+                            // math needs the post-zoom camera to convert coordinates correctly.
+                            self.parent.ensureQuestVisibleAboveSheet?(coordinate)
+                        }
                     }
                 }
 

--- a/GoInfoGame/GoInfoGame/UI/Map/MapView.swift
+++ b/GoInfoGame/GoInfoGame/UI/Map/MapView.swift
@@ -54,13 +54,26 @@ struct MapView: View {
     @State private var showElemntDeletedAlert = false
     @State private var activeConflict: PendingSyncConflict?
 
-    /// Zoom level captured right before zooming in on a selected quest, so it can be
-    /// restored once the quest sheet is dismissed (cancelled or submitted).
+    /// Zoom level and camera center captured right before zooming in on a selected
+    /// quest, so the whole camera can be restored once the quest sheet is dismissed
+    /// (cancelled or submitted) — not just the zoom.
     @State private var zoomLevelBeforeQuestSelection: Double?
+    @State private var screenWidth: CGFloat = UIScreen.main.bounds.width
+    @State private var centerBeforeQuestSelection: CLLocationCoordinate2D?
 
     /// The sync button spins whenever either queue (failed quest elements or
     /// pending notes) is actively being drained, whichever started it.
     private var isSyncing: Bool { isSyncingElements || isSyncingNotes }
+
+    /// Scales with `screenWidth` so it always leaves room for the fixed-size profile icon/divider
+    /// and the 4 trailing bar buttons, without depending on navigation/transition state.
+    private var workspaceTitleWidth: CGFloat {
+        let leadingFixedWidth: CGFloat = 75   // spacing (20) + profile icon (34) + spacing (10) + divider (1) + spacing (10)
+        let trailingFixedWidth: CGFloat = 151 // 4 icons (34 each) + 3 gaps (5 each)
+        let barPadding: CGFloat = 32          // navigation bar leading/trailing padding
+        let available = screenWidth - leadingFixedWidth - trailingFixedWidth - barPadding
+        return min(max(available, 80), 220)
+    }
 
     var body: some View {
         NavigationStack {
@@ -98,9 +111,11 @@ struct MapView: View {
                     isAnySheetBlockingSelection: isAnySheetBlockingSelection,
                     dismissOtherSheets: dismissOtherSheets,
                     previousZoomLevel: $zoomLevelBeforeQuestSelection,
+                    previousCenter: $centerBeforeQuestSelection,
                     ensureQuestVisibleAboveSheet: { coordinate in
-                        ensureCoordinateVisibleAboveSheet(coordinate, sheetHeightFraction: 0.7)
-                    }
+                        ensureCoordinateVisibleAboveSheet(coordinate, sheetHeightFraction: Self.questSheetHeightFraction)
+                    },
+                    questPathEdgePadding: questPathEdgePadding
                 )
                 .accessibilityHidden(enableAccessibility)
                 .onChange(of: tappedCoordinate) { _ in
@@ -262,6 +277,13 @@ struct MapView: View {
             } message: {
                 Text("The map area is too large. Please zoom in and try again.")
             }
+            .background(
+                GeometryReader { proxy in
+                    Color.clear
+                        .onAppear { screenWidth = proxy.size.width }
+                        .onChange(of: proxy.size.width) { screenWidth = $0 }
+                }
+            )
         }
         .environmentObject(contextualInfo)
         .navigationBarHidden(isPresented)
@@ -308,12 +330,17 @@ struct MapView: View {
                                     .multilineTextAlignment(.leading)
                             }
                         }
+                        // Fixed size so the toolbar measures this item identically on every layout pass
+                        // (an unconstrained ScrollView was sized ambiguously, which is what caused the
+                        // leading toolbar content to shift/wrap differently after returning from Profile).
+                        // Width scales with screen size via `workspaceTitleWidth`; scrolling is preserved
+                        // so the full title stays reachable at larger Dynamic Type sizes.
+                        .frame(width: workspaceTitleWidth, height: 34)
                         .accessibilityElement(children: .combine)
                         .accessibilityLabel("\(L10n.Localizable.workspace): \(selectedWorkspace.title)")
                     }
                 }
             }
-            ToolbarItem(placement: .topBarLeading) { }
 
             ToolbarItem(placement: .navigationBarTrailing) {
                 HStack(spacing: 5.0) {
@@ -384,8 +411,15 @@ struct MapView: View {
             if !newValue {
                 shouldShowPolyline = false
                 if let previousZoom = zoomLevelBeforeQuestSelection {
-                    mapViewRef?.setZoomLevel(previousZoom, animated: true)
+                    if let previousCenter = centerBeforeQuestSelection {
+                        // Animate center and zoom together so the camera eases back to
+                        // exactly where it was, instead of zooming out in place first.
+                        mapViewRef?.setCenter(previousCenter, zoomLevel: previousZoom, animated: true)
+                    } else {
+                        mapViewRef?.setZoomLevel(previousZoom, animated: true)
+                    }
                     zoomLevelBeforeQuestSelection = nil
+                    centerBeforeQuestSelection = nil
                 }
             }
         }
@@ -674,6 +708,19 @@ struct MapView: View {
     /// follow it use a 0.6-fraction bottom sheet at most — panning for that worst case
     /// up front means the pin never gets covered as the user moves between them.
     private static let noteSheetHeightFraction: CGFloat = 0.6
+
+    /// The quest-answer sheet's initial on-screen height (matches its `.fraction(0.7)`
+    /// starting detent) — used to keep a selected element, or its full path, clear of
+    /// the sheet when it's first presented.
+    private static let questSheetHeightFraction: CGFloat = 0.7
+
+    /// Edge padding for fitting a selected way's full path in view: generous enough on
+    /// the sides/top to keep it off the screen edges, with extra bottom room for the
+    /// quest sheet.
+    func questPathEdgePadding() -> UIEdgeInsets {
+        let sheetHeight = (mapViewRef?.bounds.height ?? 0) * Self.questSheetHeightFraction
+        return UIEdgeInsets(top: 60, left: 40, bottom: sheetHeight + 40, right: 40)
+    }
 
     /// If `coordinate` would currently be hidden behind the bottom sheet, pans the map
     /// just enough to bring it into the remaining visible band above the sheet.

--- a/GoInfoGame/GoInfoGame/UserProfile/View/UserProfileView.swift
+++ b/GoInfoGame/GoInfoGame/UserProfile/View/UserProfileView.swift
@@ -112,7 +112,6 @@ struct UserProfileView: View {
                 }
                 .navigationBarBackButtonHidden()
                 .navigationTitle(L10n.Localizable.myProfile)
-                // want to apply Asset.Colors.huskyPurple.swiftUIColor color to navigation title.
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {
                     ToolbarItem(placement: .navigationBarLeading) {
@@ -124,6 +123,13 @@ struct UserProfileView: View {
                                 .foregroundStyle(Asset.Colors.huskyPurple.swiftUIColor)
                                 .accessibilityLabel(L10n.Localizable.back)
                         }
+                    }
+                    // Colors just this screen's title without touching the shared UINavigationBar.appearance() proxy,
+                    // which was leaking into Map's toolbar layout when returning from this screen.
+                    ToolbarItem(placement: .principal) {
+                        Text(L10n.Localizable.myProfile)
+                            .font(.headline)
+                            .foregroundStyle(Asset.Colors.huskyPurple.swiftUIColor)
                     }
                 }
             }
@@ -141,8 +147,6 @@ struct UserProfileView: View {
                 }
             }
         }
-        // apply the modifier to set nav title color for this screen only
-        .modifier(NavigationBarTitleColorModifier(color: UIColor(Asset.Colors.huskyPurple.swiftUIColor)))
         .onAppear {
             useBiometricID = SessionManager.shared.isBiometricEnabled(for: APIConfiguration.shared.environment)
             viewModel.fetchUserProfile()
@@ -209,47 +213,6 @@ struct Line: Shape {
         path.move(to: CGPoint(x: 0, y: 0))
         path.addLine(to: CGPoint(x: rect.width, y: 0))
         return path
-    }
-}
-
-// MARK: - Navigation Bar Title Color Modifier
-/// Temporarily applies a UINavigationBarAppearance with the provided title color while the view appears,
-/// and restores the previous appearance on disappear to limit side-effects.
-private struct NavigationBarTitleColorModifier: ViewModifier {
-    let color: UIColor
-    @State private var previousStandard: UINavigationBarAppearance? = nil
-    @State private var previousScrollEdge: UINavigationBarAppearance? = nil
-    @State private var previousCompact: UINavigationBarAppearance? = nil
-
-    func body(content: Content) -> some View {
-        content
-            .onAppear {
-                // Save existing appearances
-                let proxy = UINavigationBar.appearance()
-                previousStandard = proxy.standardAppearance
-                previousScrollEdge = proxy.scrollEdgeAppearance
-                previousCompact = proxy.compactAppearance
-
-                // Create and apply new appearance
-                let newAppearance = UINavigationBarAppearance()
-                newAppearance.configureWithOpaqueBackground()
-                newAppearance.backgroundColor = .clear
-                var titleAttrs = newAppearance.titleTextAttributes
-                titleAttrs[.foregroundColor] = color
-                titleAttrs[.font] = UIFont.preferredFont(forTextStyle: .headline)
-                newAppearance.titleTextAttributes = titleAttrs
-                newAppearance.largeTitleTextAttributes = titleAttrs
-
-                proxy.standardAppearance = newAppearance
-                proxy.scrollEdgeAppearance = newAppearance
-                proxy.compactAppearance = newAppearance
-            }
-            .onDisappear {
-                let proxy = UINavigationBar.appearance()
-                if let prev = previousStandard { proxy.standardAppearance = prev }
-                if let prev = previousScrollEdge { proxy.scrollEdgeAppearance = prev }
-                if let prev = previousCompact { proxy.compactAppearance = prev }
-            }
     }
 }
 


### PR DESCRIPTION
Implemented zooming to the selected annotation and, on cancel or submission, navigating to the previous state.

Ticket: https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/4046


https://github.com/user-attachments/assets/edfe3085-2c4a-4b7d-95ea-70d0a8eb4a1d

